### PR TITLE
added 2 command-line parameters:

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,7 @@ Now you can start the server:
         --bind :8000 \
         --resource-manager-url http://resourcemanager:8088 \
         --history-server-url http://resourcemanager:19888 \
-        --namenode-address namenode:9000 \
-		--http-timeout=2 \
-		--poll-interval=2
+        --namenode-address namenode:9000
 
 And optionally, start the Slackbot:
 

--- a/main.go
+++ b/main.go
@@ -9,14 +9,15 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 var resourceManagerURL = flag.String("resource-manager-url", "http://localhost:8088", "The HTTP URL to access the resource manager.")
 var historyServerURL = flag.String("history-server-url", "http://localhost:19888", "The HTTP URL to access the history server.")
 var namenodeAddress = flag.String("namenode-address", "localhost:9000", "The host:port to access the Namenode metadata service.")
 var yarnLogDir = flag.String("yarn-logs-dir", "/tmp/logs", "The HDFS path where YARN stores logs. This is the controlled by the hadoop property yarn.nodemanager.remote-app-log-dir.")
-var httpTimeoutParam = flag.Int("http-timeout", 2, "The timeout used for connecting to YARN API.")
-var pollInterval = flag.Int("poll-interval", 2, "How often should we poll the job APIs, in seconds.")
+var httpTimeout = flag.Duration("http-timeout", time.Second*2, "The timeout used for connecting to YARN API. Pass values like: 2s")
+var pollInterval = flag.Duration("poll-interval", time.Second*2, "How often should we poll the job APIs. Pass values like: 2s")
 
 var jt jobTracker
 
@@ -112,7 +113,7 @@ func init() {
 func main() {
 	flag.Parse()
 
-	jt = newJobTracker(*resourceManagerURL, *historyServerURL, *httpTimeoutParam, *pollInterval)
+	jt = newJobTracker(*resourceManagerURL, *historyServerURL)
 	go jt.Loop()
 
 	if err := jt.TestLogsDir(); err != nil {


### PR DESCRIPTION
```
--http-timeout
--poll-interval
```

These default to the previously hard-coded values and can now be
overriden on the command line
