### PR TITLE
Support a YARN ProxyServer separate from the ResourceManager.

### DIFF
--- a/jobtracker.go
+++ b/jobtracker.go
@@ -126,18 +126,20 @@ type jobTracker struct {
 	Jobs     map[jobID]*job
 	rm       string
 	hs       string
+	ps       string
 	running  chan *job
 	finished chan *job
 	backfill chan *job
 	updates  chan *job
 }
 
-func newJobTracker(rmHost string, historyHost string) jobTracker {
+func newJobTracker(rmHost string, historyHost string, proxyHost string) jobTracker {
 	generateNewHTTPClient()
 	jt := jobTracker{
 		Jobs:     make(map[jobID]*job),
 		rm:       rmHost,
 		hs:       historyHost,
+		ps:       proxyHost,
 		running:  make(chan *job, 100),
 		finished: make(chan *job, 100),
 		backfill: make(chan *job, 100),
@@ -422,7 +424,7 @@ func (jt *jobTracker) FetchJobDetails(id string, host string) (*jobDetail, error
 	var url string
 	appID, jobID := hadoopIDs(id)
 	if host == jt.rm {
-		url = fmt.Sprintf("%s/proxy/%s/ws/v1/mapreduce/jobs", host, appID)
+		url = fmt.Sprintf("%s/proxy/%s/ws/v1/mapreduce/jobs", jt.ps, appID)
 	} else {
 		url = fmt.Sprintf("%s/ws/v1/history/mapreduce/jobs/%s", host, jobID)
 	}
@@ -444,7 +446,7 @@ func (jt *jobTracker) FetchTasks(id string, host string) (*tasks, error) {
 	var url string
 	appID, jobID := hadoopIDs(id)
 	if host == jt.rm {
-		url = fmt.Sprintf("%s/proxy/%s/ws/v1/mapreduce/jobs/%s/tasks", host, appID, jobID)
+		url = fmt.Sprintf("%s/proxy/%s/ws/v1/mapreduce/jobs/%s/tasks", jt.ps, appID, jobID)
 	} else {
 		url = fmt.Sprintf("%s/ws/v1/history/mapreduce/jobs/%s/tasks", host, jobID)
 	}
@@ -475,7 +477,7 @@ func (jt *jobTracker) FetchConf(id string, host string) (conf, error) {
 	var url string
 	appID, jobID := hadoopIDs(id)
 	if host == jt.rm {
-		url = fmt.Sprintf("%s/proxy/%s/ws/v1/mapreduce/jobs/%s/conf", host, appID, jobID)
+		url = fmt.Sprintf("%s/proxy/%s/ws/v1/mapreduce/jobs/%s/conf", jt.ps, appID, jobID)
 	} else {
 		url = fmt.Sprintf("%s/ws/v1/history/mapreduce/jobs/%s/conf", host, jobID)
 	}
@@ -506,7 +508,7 @@ func (jt *jobTracker) FetchCounters(id string, host string) ([]counter, error) {
 	var url string
 	appID, jobID := hadoopIDs(id)
 	if host == jt.rm {
-		url = fmt.Sprintf("%s/proxy/%s/ws/v1/mapreduce/jobs/%s/counters", host, appID, jobID)
+		url = fmt.Sprintf("%s/proxy/%s/ws/v1/mapreduce/jobs/%s/counters", jt.ps, appID, jobID)
 	} else {
 		url = fmt.Sprintf("%s/ws/v1/history/mapreduce/jobs/%s/counters", host, jobID)
 	}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 
 var resourceManagerURL = flag.String("resource-manager-url", "http://localhost:8088", "The HTTP URL to access the resource manager.")
 var historyServerURL = flag.String("history-server-url", "http://localhost:19888", "The HTTP URL to access the history server.")
+var proxyServerURL = flag.String("proxy-server-url", "", "The HTTP URL to access the proxy server, if separate from the resource manager.")
 var namenodeAddress = flag.String("namenode-address", "localhost:9000", "The host:port to access the Namenode metadata service.")
 var yarnLogDir = flag.String("yarn-logs-dir", "/tmp/logs", "The HDFS path where YARN stores logs. This is the controlled by the hadoop property yarn.nodemanager.remote-app-log-dir.")
 var httpTimeout = flag.Duration("http-timeout", time.Second*2, "The timeout used for connecting to YARN API. Pass values like: 2s")
@@ -113,7 +114,11 @@ func init() {
 func main() {
 	flag.Parse()
 
-	jt = newJobTracker(*resourceManagerURL, *historyServerURL)
+	if *proxyServerURL == "" {
+		proxyServerURL = resourceManagerURL
+	}
+
+	jt = newJobTracker(*resourceManagerURL, *historyServerURL, *proxyServerURL)
 	go jt.Loop()
 
 	if err := jt.TestLogsDir(); err != nil {


### PR DESCRIPTION
We run a separate YARN ProxyServer instance, instead of using the ProxyServer embedded in the ResourceManager (yarn-site.xml config option yarn.web-proxy.address).

This adds a command line option to specify the proxy server address. 