### PR TITLE
Making the sse fail continue instead of break

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -72,7 +72,7 @@ func (sse *sse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		event = bytes.Replace(event, newline, prefix, -1)
 		if _, err := fmt.Fprintf(w, "data: %s\n\n", event); err != nil {
 			log.Println("Error writing to SSE", id, header, err)
-			break
+			continue
 		}
 		w.(http.Flusher).Flush()
 	}


### PR DESCRIPTION
We've seen Timberlake hang after a broken pipe, and this solved that problem for us. 
Timberlake was processing the histories but as soon as the logs outputted the SSE write error, it stopped processing the currently running jobs. 