### PR TITLE
slackbot connection needs to close

### DIFF
--- a/bots/slack.go
+++ b/bots/slack.go
@@ -169,6 +169,7 @@ func alert(job Job) {
 		fmt.Println(err)
 	}
 	fmt.Println(resp)
+        defer resp.Body.Close()
 }
 
 func cleanName(name string) string {


### PR DESCRIPTION
Our slackbot was hanging because of "too many open files", I think this will solve the issue.