### PR TITLE
actually sort by duration

### DIFF
--- a/js/app.jsx
+++ b/js/app.jsx
@@ -276,7 +276,7 @@ var JobTable = {
         case 'name': return row.name;
         case 'started': return row.startTime;
         case 'finished': return row.finishTime;
-        case 'duration': return -row.startTime;
+        case 'duration': return row.duration(); 
         case 'map': return row.maps.progress;
         case 'reduce': return row.reduces.progress;
         case 'state': return row.state;


### PR DESCRIPTION
Duration was using -row.startTime, and wasn't sorting by actual duration.