### PR TITLE
Fix mapper count on the home page

### DIFF
--- a/js/app.jsx
+++ b/js/app.jsx
@@ -25,7 +25,7 @@ class NavBar extends React.Component {
             <a className="navbar-brand" href="#">Timberlake</a>
           </div>
           <div className="navbar-right">
-            <p className="navbar-text">mappers: {numFormat(reducers)}</p>
+            <p className="navbar-text">mappers: {numFormat(mappers)}</p>
             <p className="navbar-text">reducers: {numFormat(reducers)}</p>
           </div>
         </div>


### PR DESCRIPTION
The mapper count was inadvertently set to the reducer count.