### PR TITLE
[DATA-2513] Fixed the job ID extraction regex.

### DIFF
--- a/js/components/related-dag.jsx
+++ b/js/components/related-dag.jsx
@@ -90,7 +90,7 @@ export default class extends React.Component {
 
       // Create a graph node.
       g.setNode(job.id, {
-        label: /^[^0-9]+\(([0-9]+)/.exec(job.name)[1],
+        label: /^[^\(]+\(([0-9]+)/.exec(job.name)[1],
         key: job.id,
         width: size,
         height: size


### PR DESCRIPTION
Fixes a JS error caused by a regex not correctly handling digits in job names.