### PR TITLE
Unbreak master and more

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,6 @@
         "eqeqeq": "warn",
         "import/no-mutable-exports": "warn",
         "no-cond-assign": "warn",
-        "no-param-reassign": "warn",
         "no-redeclare": "warn",
         "no-restricted-syntax": "warn",
         "no-return-assign": "warn",

--- a/js/job.jsx
+++ b/js/job.jsx
@@ -377,8 +377,8 @@ class Waterfall extends React.Component {
   }
 }
 
-function waterfall(data, node, opts) {
-  var defaults = {
+function waterfall(data, node, optsIn) {
+  const defaults = {
     lineHeight: 1,
     barHeight: 1,
     width: 550,
@@ -388,15 +388,15 @@ function waterfall(data, node, opts) {
       return d.type == 'map' ? COLOUR_MAP : COLOUR_REDUCE;
     },
   };
-  opts = _.extend(defaults, opts);
+  const opts = _.extend(defaults, optsIn);
 
-  var margin = {
+  const margin = {
     top: 10, right: 20, bottom: 20, left: 20,
   };
-  var width = opts.width - margin.left - margin.right;
-  var height = Math.max(100, data.length * opts.lineHeight) - margin.top - margin.bottom;
+  const width = opts.width - margin.left - margin.right;
+  const height = Math.max(100, data.length * opts.lineHeight) - margin.top - margin.bottom;
 
-  var chart = d3.waterfall()
+  const chart = d3.waterfall()
     .width(width)
     .height(height)
     .barHeight(opts.barHeight)
@@ -404,8 +404,8 @@ function waterfall(data, node, opts) {
     .linkFormat(opts.linkFormat)
     .barStyle(opts.fillStyle);
 
-  var start = d3.min(_.pluck(data, 'start'));
-  var finish = d3.max(_.pluck(data, 'finish'));
+  const start = d3.min(_.pluck(data, 'start'));
+  const finish = d3.max(_.pluck(data, 'finish'));
   chart.domain([start, finish]);
 
   if (((finish - start) / 1000) < 180) {

--- a/js/jobrow.jsx
+++ b/js/jobrow.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import {Link, hashHistory} from 'react-router';
+
+import {
+  timeFormat,
+  secondFormat,
+  jobState,
+} from './utils';
+import ProgressBar from './components/progress-bar';
+
+// Lifted from react-router.
+const isLeftClickEvent = (e) => e.button === 0;
+const isModifiedEvent = (event) => event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
+
+class JobRow extends React.Component {
+  constructor() {
+    super();
+    this.onClick = this.onClick.bind(this);
+  }
+
+  onClick(e) {
+    if (isLeftClickEvent(e) && !isModifiedEvent(e)) {
+      hashHistory.push(`/job/${this.props.job.id}`);
+    }
+  }
+
+  render() {
+    const columns = this.columns();
+    return <tr onClick={this.onClick.bind(this)}>{columns.map((d, i) => <td key={i}>{d}</td>)}</tr>;
+  }
+}
+
+export class RunningJobRow extends JobRow {
+  columns() {
+    const {job} = this.props;
+    return [
+      job.user,
+      <Link to={`/job/${job.id}`}>{job.name}</Link>,
+      timeFormat(job.startTime),
+      secondFormat(job.duration()),
+      <ProgressBar value={job.maps.progress} />,
+      <ProgressBar value={job.reduces.progress} />,
+    ];
+  }
+}
+
+export class FinishedJobRow extends JobRow {
+  columns() {
+    const {job} = this.props;
+    return [
+      job.user,
+      <Link to={`/job/${job.id}`}>{job.name}</Link>,
+      timeFormat(job.startTime),
+      timeFormat(job.finishTime),
+      secondFormat(job.duration()),
+      jobState(job),
+    ];
+  }
+}

--- a/js/list.jsx
+++ b/js/list.jsx
@@ -1,20 +1,14 @@
 import React from 'react';
-import {Link, hashHistory} from 'react-router';
-
+import {hashHistory} from 'react-router';
+import {FinishedJobRow, RunningJobRow} from './jobrow';
 import {
-  timeFormat,
-  secondFormat,
-  jobState,
   ACTIVE_STATES,
   FINISHED_STATES,
 } from './utils';
-import ProgressBar from './components/progress-bar';
 
 const {_} = window;
 
-// Lifted from react-router.
-const isLeftClickEvent = (e) => e.button === 0;
-const isModifiedEvent = (event) => event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
+const HEADERS = ['user', 'name', 'started', 'duration', 'map', 'reduce'];
 
 export default class extends React.Component {
   constructor(props) {
@@ -155,11 +149,10 @@ class FinishedJobs extends JobTable {
     super(props);
 
     this.sortKey = 'fsort';
-    this.filterKey = 'filter';
     this.states = FINISHED_STATES;
     this.defaultSortKey = '-finished';
     this.title = 'Finished';
-    this.headers = 'user name started finished duration state'.split(' ');
+    this.headers = HEADERS;
     this.rowClass = () => FinishedJobRow;
   }
 }
@@ -169,59 +162,12 @@ class RunningJobs extends JobTable {
     super(props);
 
     this.sortKey = 'rsort';
-    this.filterKey = 'filter';
     this.states = ACTIVE_STATES;
     this.defaultSortKey = '-started';
     this.title = 'Running';
-    this.headers = 'user name started duration map reduce'.split(' ');
+    this.headers = HEADERS;
     this.rowClass = () => RunningJobRow;
     this.autoFocus = true;
   }
 }
 
-class JobRow extends React.Component {
-  constructor() {
-    super();
-    this.onClick = this.onClick.bind(this);
-  }
-
-  onClick(e) {
-    if (isLeftClickEvent(e) && !isModifiedEvent(e)) {
-      hashHistory.push(`/job/${this.props.job.id}`);
-    }
-  }
-
-  render() {
-    const columns = this.columns();
-    return <tr onClick={this.onClick.bind(this)}>{columns.map((d, i) => <td key={i}>{d}</td>)}</tr>;
-  }
-}
-
-class RunningJobRow extends JobRow {
-  columns() {
-    const {job} = this.props;
-    return [
-      job.user,
-      <Link to={`/job/${job.id}`}>{job.name}</Link>,
-      timeFormat(job.startTime),
-      secondFormat(job.duration()),
-      <ProgressBar value={job.maps.progress} />,
-      <ProgressBar value={job.reduces.progress} />,
-    ];
-  }
-}
-
-
-class FinishedJobRow extends JobRow {
-  columns() {
-    const {job} = this.props;
-    return [
-      job.user,
-      <Link to={`/job/${job.id}`}>{job.name}</Link>,
-      timeFormat(job.startTime),
-      timeFormat(job.finishTime),
-      secondFormat(job.duration()),
-      jobState(job),
-    ];
-  }
-}

--- a/js/mr.jsx
+++ b/js/mr.jsx
@@ -2,18 +2,20 @@ import {
   cleanJobName,
 } from './utils';
 
-const {_} = window._;
+const {_} = window;
 
-export var notAvailable = {};
+export const notAvailable = {};
 
 export class MRJob {
   constructor(data) {
-    var _m;
-    var d = data.details;
+    const d = data.details;
     this.id = d.id.replace('application_', 'job_');
     this.fullName = d.name;
     this.name = cleanJobName(d.name);
-    this.taskFamily = (_m = /^\[(\w+)\/\w+\]/.exec(d.name)) ? _m[1] : undefined;
+    const _m = /^\[(\w+)\/\w+]/.exec(d.name);
+    if (_m) {
+      [, this.taskFamily] = _m;
+    }
     this.state = d.state;
     this.startTime = d.startTime ? new Date(d.startTime) : new Date();
     this.startTime.setMilliseconds(0);
@@ -46,7 +48,7 @@ export class MRJob {
 
     this.counters = new MRCounters(data.counters);
 
-    var tasks = data.tasks || {};
+    const tasks = data.tasks || {};
     this.tasks = {
       maps: (tasks.maps || []).map((taskData) => new MRTask(taskData)),
       reduces: (tasks.reduces || []).map((taskData) => new MRTask(taskData)),
@@ -78,7 +80,7 @@ export class MRCounters {
 
 export class MRTask {
   constructor(data) {
-    var [start, finish] = data;
+    const [start, finish] = data;
     this.startTime = start ? new Date(start) : new Date();
     this.startTime.setMilliseconds(0);
     this.finishTime = finish ? new Date(finish) : null;

--- a/js/store.js
+++ b/js/store.js
@@ -22,7 +22,7 @@ class JobStore {
   }
 
   startSSE() {
-    var sse = new EventSource('/sse');
+    const sse = new EventSource('/sse');
     sse.onmessage = (e) => {
       this.trigger('job', new MRJob(JSON.parse(e.data)));
     };
@@ -37,4 +37,4 @@ class JobStore {
   }
 }
 
-export var Store = new JobStore();
+export const Store = new JobStore();

--- a/js/utils.jsx
+++ b/js/utils.jsx
@@ -1,33 +1,32 @@
 import React from 'react';
 
-const {d3} = window.d3;
+const {d3} = window;
 
-export var paddedInt = d3.format('02d');
-export var timeFormat = d3.time.format.utc('%a %H:%M:%S');
-export var lolhadoop = (s) => s.replace(/application|job/, '');
+export const paddedInt = d3.format('02d');
+export const timeFormat = d3.time.format.utc('%a %H:%M:%S');
+export const lolhadoop = (s) => s.replace(/application|job/, '');
 
 export function numFormat(n) {
-  if (!n) n = 0;
-  return d3.format(',d')(n);
+  return d3.format(',d')(n || 0);
 }
 
-export function secondFormat(n) {
-  n /= 1000;
-  var hour = Math.floor(n / 3600);
-  var minute = Math.floor(n % 3600 / 60);
-  var second = Math.floor(n % 3600 % 60);
+export function secondFormat(ms) {
+  const n = ms / 1000;
+  const hour = Math.floor(n / 3600);
+  const minute = Math.floor(n % 3600 / 60);
+  const second = Math.floor(n % 3600 % 60);
   return `${numFormat(hour)}:${paddedInt(minute)}:${paddedInt(second)}`;
 }
 
 export function plural(n, s) {
-  return n == 1 ? s : `${s}s`;
+  return n === 1 ? s : `${s}s`;
 }
 
-export function humanFormat(n) {
-  n /= 1000;
-  var hour = Math.floor(n / 3600);
-  var minute = Math.floor(n % 3600 / 60);
-  var second = Math.floor(n % 3600 % 60);
+export function humanFormat(ms) {
+  const n = ms / 1000;
+  const hour = Math.floor(n / 3600);
+  const minute = Math.floor(n % 3600 / 60);
+  const second = Math.floor(n % 3600 % 60);
   if (n < 60) {
     return second + plural(second, ' second');
   } else if (n < 3600) {
@@ -37,9 +36,9 @@ export function humanFormat(n) {
 }
 
 
-export var ACTIVE_STATES = ['RUNNING', 'ACCEPTED'];
-export var FINISHED_STATES = ['SUCCEEDED', 'KILLED', 'FAILED', 'ERROR'];
-export var FAILED_STATES = ['FAILED', 'KILLED', 'ERROR'];
+export const ACTIVE_STATES = ['RUNNING', 'ACCEPTED'];
+export const FINISHED_STATES = ['SUCCEEDED', 'KILLED', 'FAILED', 'ERROR'];
+export const FAILED_STATES = ['FAILED', 'KILLED', 'ERROR'];
 
 export function jobState(job) {
   const {state} = job;
@@ -60,9 +59,9 @@ export function cleanJobName(name) {
 
 export function cleanJobPath(path) {
   if (!path) return path;
-  path = path.replace(/hdfs:\/\/\w+(\.\w+)*:\d+/g, '');
-  path = path.replace(/,/, ', ');
-  return path;
+  return path
+    .replace(/hdfs:\/\/\w+(\.\w+)*:\d+/g, '')
+    .replace(/,/, ', ');
 }
 
 export const COLOUR_MAP = 'rgb(91, 192, 222)';


### PR DESCRIPTION
Fixes two fatal bugs in https://github.com/stripe/timberlake/pull/67 relating to destructuring global vars: `const {_} = window._;` should have been `const {_} = window;` and likewise for s/_/d3/.

Also includes a bunch of other fixes that were in flight, including fixing `no-param-reassign`, moving the JobRow components to their own file, and fixing a bunch of `var` usage.

r? @mdoan-stripe 