### PR TITLE
Use HENSON_SERVICE in henson/restart

### DIFF
--- a/henson/restart
+++ b/henson/restart
@@ -1,4 +1,4 @@
 #!/bin/bash -eux
 
-svc -t /etc/service/jobtracker-srv
+svc -t /etc/service/${HENSON_SERVICE}
 svc -t /etc/service/jobtracker-bot


### PR DESCRIPTION
Fixes an issue where deploying any service would deploy jobtracker-srv rather than the target service. (jobtracker-bot is currently a shared service.)

Test plan: deployed a non-jobtracker-srv from this branch 🎉 

r? @stripe/data-platform 
