### PR TITLE
Update package.json for 0.1.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "timberlake",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Timberlake is a Job Tracker for Hadoop.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/stripe/timberlake.git"
   },
-  "author": "Jeff Balogh",
+  "author": "Stripe, Inc.",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/stripe/timberlake/issues"
@@ -32,7 +32,7 @@
   },
   "main": "gulpfile.js",
   "directories": {
-    "test": "test"
+    "bin": "./bin"
   },
   "scripts": {
     "test": "eslint --ext .js --ext .jsx ."


### PR DESCRIPTION
I'd like to cut a 0.1.0 release ahead of some major changes (statsd, multicluster support). This updates the `package.json` to be consistent with that.

It also updates the `author` and `directories` entries. (tests don't live in `test`)

r? @stripe/data-platform 
cc @jbalogh-stripe 