### PR TITLE
Better error logging on invalid JSON response

### DIFF
--- a/jobtracker.go
+++ b/jobtracker.go
@@ -79,7 +79,7 @@ func getJSON(url string, data interface{}) error {
 	}
 	err = json.Unmarshal(jsonBytes, data)
 	if err != nil {
-		log.Printf("Response is not valid JSON:\n%s", string(jsonBytes[:]))
+		log.Printf("Response is not valid JSON:\n%s\n", string(jsonBytes[:]))
 	}
 	return err
 }

--- a/jobtracker.go
+++ b/jobtracker.go
@@ -77,8 +77,11 @@ func getJSON(url string, data interface{}) error {
 	if err != nil {
 		return err
 	}
-
-	return json.Unmarshal(jsonBytes, data)
+	err = json.Unmarshal(jsonBytes, data)
+	if err != nil {
+		log.Printf("Response is not valid JSON:\n%s", string(jsonBytes[:]))
+	}
+	return err
 }
 
 type jobTracker struct {
@@ -135,7 +138,7 @@ func (jt *jobTracker) runningJobLoop() {
 		}()
 	}
 
-	for _ = range time.Tick(*pollInterval) {
+	for range time.Tick(*pollInterval) {
 		running, err := jt.listJobs()
 		if err != nil {
 			log.Println("Error listing running jobs:", err)


### PR DESCRIPTION
We sometimes see cryptic log lines that look like this:
```
[2017-10-31 20:19:14.406845] 2017/10/31 20:19:14 Error listing running jobs: invalid character 'T' looking for beginning of value
```

This is due to attempting to parse invalid JSON. This change introduces additional logging to print the string that was attempted to parse as JSON, e.g.:

```
[2017-10-31 20:19:14.406720] 2017/10/31 20:19:14 Response is not valid JSON:
[2017-10-31 20:19:14.406789] This is standby RM. Redirecting to the current active RM: $URL
[2017-10-31 20:19:14.406845] 2017/10/31 20:19:14 Error listing running jobs: invalid character 'T' looking for beginning of value
```
(Per https://issues.apache.org/jira/browse/YARN-3526, this specific error is likely fixed in more recent releases of Hadoop)

r? @stripe/data-platform 