### PR TITLE
Manually fix no-restricted-syntax violations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,6 @@
     "rules": {
         "class-methods-use-this": ["error", {"exceptMethods": ["render"]}],
         "eqeqeq": "warn",
-        "no-restricted-syntax": "warn",
         "react/jsx-no-bind": "warn",
         "react/no-array-index-key": "warn"
     }

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,4 @@
+**.min.css
+**.min.js
+test/sleepjob.jhist
+vendor/github.com/

--- a/js/app.jsx
+++ b/js/app.jsx
@@ -59,19 +59,19 @@ class App extends React.Component {
     const jobs = _.extend(this.state.jobs, this.updates);
 
     // Drop mapper, reducer & config info of jobs that are not viewed on the detail page.
-    for (const key in jobs) {
-      if (key != Store.lastJob) {
+    Object.keys(jobs).forEach((key) => {
+      if (key !== Store.lastJob) {
         jobs[key].compact();
       }
-    }
+    });
 
     // Drop old finished jobs, keeping only 5000 of them.
-    const ids = Object.keys(jobs).filter((id) => jobs[id].finishTime != null && id != Store.lastJob);
+    const ids = Object.keys(jobs).filter((id) => jobs[id].finishTime !== null && id !== Store.lastJob);
     if (ids.length > JOBS_TO_KEEP) {
       ids.sort((a, b) => jobs[a].finishTime - jobs[b].finishTime);
-      for (const id of _.first(ids, ids.length - JOBS_TO_KEEP)) {
+      _.first(ids, ids.length - JOBS_TO_KEEP).forEach((id) => {
         delete jobs[id];
-      }
+      });
     }
 
     this.setState({jobs});

--- a/js/components/related-dag.jsx
+++ b/js/components/related-dag.jsx
@@ -28,18 +28,18 @@ export default class extends React.Component {
     const inputMap = [];
     const outputMap = [];
     const files = new Set();
-    for (const currentJob of jobs) {
+    jobs.forEach((currentJob) => {
       // Find input & output jobs.
       const inputs = currentJob.conf.input ? currentJob.conf.input.split(/,/g) : [];
-      for (const input of inputs) {
+      inputs.forEach((input) => {
         (inputMap[input] = inputMap[input] || []).push(currentJob.id);
         files.add(input);
-      }
+      });
       const outputs = currentJob.conf.output ? currentJob.conf.output.split(/,/g) : [];
-      for (const output of outputs) {
+      outputs.forEach((output) => {
         (outputMap[output] = outputMap[output] || []).push(currentJob.id);
         files.add(output);
-      }
+      });
 
       // Create a graph node.
       g.setNode(currentJob.id, {
@@ -48,16 +48,16 @@ export default class extends React.Component {
         width: size,
         height: size,
       });
-    }
+    });
 
     // Link jobs based on their inputs & outputs.
-    for (const file of files) {
-      for (const input of inputMap[file] || []) {
-        for (const output of outputMap[file] || []) {
+    files.forEach((file) => {
+      (inputMap[file] || []).forEach((input) => {
+        (outputMap[file] || []).forEach((output) => {
           g.setEdge(output, input);
-        }
-      }
-    }
+        });
+      });
+    });
 
     dagre.layout(g);
 
@@ -93,7 +93,7 @@ export default class extends React.Component {
               {g.nodes().map((id, i) => (<DAGNode
                 key={i}
                 node={g.node(id)}
-                selected={id == job.id}
+                selected={id === job.id}
                 hover={this.props.hover}
               />))}
             </g>

--- a/js/job.jsx
+++ b/js/job.jsx
@@ -23,7 +23,7 @@ import {notAvailable} from './mr';
 const {$, _, d3} = window;
 
 function bytesFormat(n) {
-  if (n == notAvailable || !n) return null;
+  if (n === notAvailable || !n) return null;
   const M = 1024.0 * 1024;
   const G = M * 1024;
   if (n < G) {
@@ -40,14 +40,13 @@ function inputs(job, allJobs) {
 }
 
 function relatedJobs(job, allJobs) {
-  return allJobs.filter((d) => d.fullName.indexOf(job.taskFamily) == 1);
+  return allJobs.filter((d) => d.fullName.indexOf(job.taskFamily) === 1);
 }
 
 export default class extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-    };
+    this.state = {};
 
     this.kill = this.kill.bind(this);
     this.handleShowKillModal = this.handleShowKillModal.bind(this);
@@ -60,7 +59,7 @@ export default class extends React.Component {
   }
 
   componentWillReceiveProps(next) {
-    if (this.props.params.jobId != next.params.jobId) {
+    if (this.props.params.jobId !== next.params.jobId) {
       Store.getJob(next.params.jobId);
     }
   }
@@ -71,7 +70,7 @@ export default class extends React.Component {
 
   getJob() {
     const jobId = lolhadoop(this.props.params.jobId);
-    return _.find(this.props.jobs, (d) => lolhadoop(d.id) == jobId);
+    return _.find(this.props.jobs, (d) => lolhadoop(d.id) === jobId);
   }
 
   kill() {
@@ -114,7 +113,7 @@ export default class extends React.Component {
       </ul>
     );
 
-    let similar = this.props.jobs.filter((j) => j.name.indexOf(job.name) != -1);
+    let similar = this.props.jobs.filter((j) => j.name.indexOf(job.name) !== -1);
     similar = similar.filter((j) => j.startTime < job.startTime);
     const prev = _.last(_.sortBy(similar, 'startTime'));
     const previous = prev ? <Link to={`job/${prev.id}`}>previous: {secondFormat(prev.duration())}</Link> : null;
@@ -174,9 +173,9 @@ export default class extends React.Component {
     };
     bytes.total_read = bytes.hdfs_read + bytes.s3_read + bytes.file_read;
     bytes.total_written = bytes.hdfs_written + bytes.s3_written + bytes.file_written;
-    for (const key of Object.keys(bytes)) {
+    Object.keys(bytes).forEach((key) => {
       bytes[key] = bytesFormat(bytes[key]);
-    }
+    });
     const bytesReadTitle = `HDFS: ${bytes.hdfs_read}\nS3: ${bytes.s3_read}\nFile: ${bytes.file_read}`;
     const bytesWrittenTitle = `HDFS: ${bytes.hdfs_written}\nS3: ${bytes.s3_written}\nFile: ${bytes.file_written}`;
 


### PR DESCRIPTION
Manually fixes `no-restricted-syntax` violations (as well as some `eqeqeq` violations while i was in the neighborhood). Verified via edge deploy. Only three overrides left to fix (we're probably stuck with `class-methods-use-this`)!

r? @stripe/data-platform 