### PR TITLE
Fix DOM node refs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,10 +14,5 @@
     },
     "plugins": [
         "react"
-    ],
-    "rules": {
-        "eqeqeq": "warn",
-        "react/jsx-no-bind": "warn",
-        "react/no-array-index-key": "warn"
-    }
+    ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,6 @@
         "react"
     ],
     "rules": {
-        "class-methods-use-this": ["error", {"exceptMethods": ["render"]}],
         "eqeqeq": "warn",
         "react/jsx-no-bind": "warn",
         "react/no-array-index-key": "warn"

--- a/css/app.css
+++ b/css/app.css
@@ -87,7 +87,7 @@ a:hover,
   border: #ccc solid 1px;
   width: 100px;
   height: 22px;
-  vertical-align: midle;
+  vertical-align: middle;
   overflow: hidden;
   font-weight: 700;
   box-shadow: 0 4px 10px -5px rgba(0, 0, 0, 0.25);

--- a/js/JobTable.jsx
+++ b/js/JobTable.jsx
@@ -18,7 +18,7 @@ class JobTable extends React.Component {
 
   sort(key) {
     const s = JobTable.sorting(this.props.query[this.sortKey] || this.defaultSortKey);
-    const n = s.key == key && s.dir == -1 ? key : `-${key}`;
+    const n = s.key == key && s.dir == -1 ? key : `-${key}`; // eslint-disable-line eqeqeq
     const q = _.object([[this.sortKey, n]]);
 
     hashHistory.push({
@@ -49,7 +49,7 @@ class JobTable extends React.Component {
         default: return undefined;
       }
     });
-    if (sort.dir == -1) jobs.reverse();
+    if (sort.dir == -1) jobs.reverse(); // eslint-disable-line eqeqeq
     return [sort, jobs];
   }
 
@@ -74,8 +74,8 @@ class JobTable extends React.Component {
           <thead>
             <tr>
               {this.headers.map((h) => {
-                const cls = sort.key == h ? sortDir : '';
-                const click = this.sort.bind(this, h);
+                const cls = sort.key == h ? sortDir : ''; // eslint-disable-line eqeqeq
+                const click = this.sort.bind(this, h); // eslint-disable-line react/jsx-no-bind
                 return <th key={h} className={cls} onClick={click}>{h}</th>;
               })}
             </tr>

--- a/js/components/BoxPlot.jsx
+++ b/js/components/BoxPlot.jsx
@@ -60,6 +60,6 @@ export default class extends React.Component {
   }
 
   render() {
-    return <div />;
+    return <div ref={(node) => { this.node = node; }} />;
   }
 }

--- a/js/components/RelatedJobs.jsx
+++ b/js/components/RelatedJobs.jsx
@@ -26,9 +26,9 @@ export default class extends React.Component {
     const fmt = (d) => `${secondFormat(d.job.duration())} ${d.job.name}`;
     const links = (d) => `#/job/${d.job.id}`;
     const fs = (d) => {
-      if (d.job.id == job.id) {
+      if (d.job.id == job.id) { // eslint-disable-line eqeqeq
         return COLOUR_SELECTED;
-      } else if (hover && d.job.id == hover.id) {
+      } else if (hover && d.job.id == hover.id) { // eslint-disable-line eqeqeq
         return COLOUR_HOVER;
       } else {
         return COLOUR_MAP;

--- a/js/components/Summarizer.jsx
+++ b/js/components/Summarizer.jsx
@@ -13,7 +13,7 @@ export default class extends React.Component {
     const {progress} = this.props;
     const inputRecords = this.props.input_records;
     const outputRecords = this.props.output_records;
-    const recordsPerSec = inputRecords != notAvailable ? Math.floor(inputRecords / (progress.totalTime / 1000)) : null;
+    const recordsPerSec = inputRecords != notAvailable ? Math.floor(inputRecords / (progress.totalTime / 1000)) : null; // eslint-disable-line eqeqeq
     const computeTime = recordsPerSec ?
       <span>{humanFormat(progress.totalTime)}<br />{numFormat(recordsPerSec)} {plural(recordsPerSec, 'record')}/sec</span>
       : <span>{humanFormat(progress.totalTime)}</span>;
@@ -25,14 +25,16 @@ export default class extends React.Component {
       ['Pending', numFormat(progress.pending)],
       ['Killed', numFormat(progress.killed)],
       ['Failed', numFormat(progress.failed)],
-      ['Input Records', inputRecords != notAvailable ? numFormat(inputRecords) : null],
-      ['Output Records', outputRecords != notAvailable ? numFormat(outputRecords) : null],
+      ['Input Records', inputRecords != notAvailable ? numFormat(inputRecords) : null], // eslint-disable-line eqeqeq
+      ['Output Records', outputRecords != notAvailable ? numFormat(outputRecords) : null], // eslint-disable-line eqeqeq
       ['Compute Time', progress.totalTime > 0 ? computeTime : null],
     ];
+    /* eslint-disable react/no-array-index-key */
     return (
       <table className="table">
         <tbody>{pairs.map((t, i) => <tr key={i}><th>{t[0]}</th><td>{t[1]}</td></tr>)}</tbody>
       </table>
     );
+    /* eslint-enable react/no-array-index-key */
   }
 }

--- a/js/components/Waterfall.jsx
+++ b/js/components/Waterfall.jsx
@@ -65,6 +65,6 @@ export default class extends React.Component {
   }
 
   render() {
-    return <div />;
+    return <div ref={(node) => { this.node = node; }} />;
   }
 }

--- a/js/components/Waterfall.jsx
+++ b/js/components/Waterfall.jsx
@@ -14,7 +14,7 @@ function waterfall(data, node, optsIn) {
     textFormat: (t) => '',
     linkFormat: null,
     fillStyle: (d) => {
-      return d.type == 'map' ? COLOUR_MAP : COLOUR_REDUCE;
+      return d.type == 'map' ? COLOUR_MAP : COLOUR_REDUCE; // eslint-disable-line eqeqeq
     },
   };
   const opts = _.extend(defaults, optsIn);

--- a/js/components/related-dag.jsx
+++ b/js/components/related-dag.jsx
@@ -70,6 +70,7 @@ export default class extends React.Component {
       height = Math.max(height, node.y + margin * 2 + size);
     });
 
+    /* eslint-disable react/no-array-index-key */
     return (
       <div>
         <h4>DAG</h4>
@@ -101,5 +102,6 @@ export default class extends React.Component {
         </div>
       </div>
     );
+    /* eslint-enable react/no-array-index-key */
   }
 }

--- a/js/job.jsx
+++ b/js/job.jsx
@@ -96,7 +96,6 @@ export default class extends React.Component {
   }
 
   render() {
-    console.time('Render Job');
     const job = this.getJob();
     if (!job) return null;
     document.title = job.name;
@@ -246,7 +245,6 @@ export default class extends React.Component {
       </div>
     );
     /* eslint-enable react/no-array-index-key */
-    console.timeEnd('Render Job');
     return rv;
   }
 }

--- a/js/job.jsx
+++ b/js/job.jsx
@@ -100,6 +100,7 @@ export default class extends React.Component {
     const job = this.getJob();
     if (!job) return null;
     document.title = job.name;
+    /* eslint-disable react/no-array-index-key */
     const renderedInputs = (
       <ul className="list-unstyled">
         {inputs(job, this.props.jobs).map((input, i) =>
@@ -112,6 +113,7 @@ export default class extends React.Component {
           ))}
       </ul>
     );
+    /* eslint-enable react/no-array-index-key */
 
     let similar = this.props.jobs.filter((j) => j.name.indexOf(job.name) !== -1);
     similar = similar.filter((j) => j.startTime < job.startTime);
@@ -154,11 +156,13 @@ export default class extends React.Component {
         const matches = trimmed.match(/[\w.]+:\d+/i);
         return {full: trimmed, short: matches ? matches[0] : trimmed};
       });
+      /* eslint-disable react/no-array-index-key */
       const steps = (
         <ul className="list-unstyled">
           {_.uniq(lines).map((line, i) => <li key={i}><span className="scalding-step-description" title={line.full}>{line.short}</span></li>)}
         </ul>
       );
+      /* eslint-enable react/no-array-index-key */
       pairs.push(['Line Numbers', steps]);
     }
 
@@ -181,6 +185,7 @@ export default class extends React.Component {
 
     const sortedRelatedJobs = _.sortBy(relatedJobs(job, this.props.jobs), (relatedJob) => relatedJob.id);
 
+    /* eslint-disable react/no-array-index-key */
     const rv = (
       <div>
         <div className="row">
@@ -240,6 +245,7 @@ export default class extends React.Component {
         </div>
       </div>
     );
+    /* eslint-enable react/no-array-index-key */
     console.timeEnd('Render Job');
     return rv;
   }

--- a/js/jobconf.jsx
+++ b/js/jobconf.jsx
@@ -12,14 +12,14 @@ export default class extends React.Component {
   }
 
   componentWillReceiveProps(next) {
-    if (this.props.params.jobId != next.params.jobId) {
+    if (this.props.params.jobId != next.params.jobId) { // eslint-disable-line eqeqeq
       Store.getJob(next.params.jobId);
     }
   }
 
   getJob() {
     const jobId = lolhadoop(this.props.params.jobId);
-    return _.find(this.props.jobs, (d) => lolhadoop(d.id) == jobId);
+    return _.find(this.props.jobs, (d) => lolhadoop(d.id) == jobId); // eslint-disable-line eqeqeq
   }
 
   render() {

--- a/js/jobcounters.jsx
+++ b/js/jobcounters.jsx
@@ -12,14 +12,14 @@ export default class extends React.Component {
   }
 
   componentWillReceiveProps(next) {
-    if (this.props.params.jobId != next.params.jobId) {
+    if (this.props.params.jobId != next.params.jobId) { // eslint-disable-line eqeqeq
       Store.getJob(next.params.jobId);
     }
   }
 
   getJob() {
     const jobId = lolhadoop(this.props.params.jobId);
-    return _.find(this.props.jobs, (d) => lolhadoop(d.id) == jobId);
+    return _.find(this.props.jobs, (d) => lolhadoop(d.id) == jobId); // eslint-disable-line eqeqeq
   }
 
   render() {

--- a/js/joblogs.jsx
+++ b/js/joblogs.jsx
@@ -12,14 +12,14 @@ export default class extends React.Component {
   }
 
   componentWillReceiveProps(next) {
-    if (this.props.params.jobId != next.params.jobId) {
+    if (this.props.params.jobId != next.params.jobId) { // eslint-disable-line eqeqeq
       Store.getJob(next.params.jobId);
     }
   }
 
   getJob() {
     const jobId = lolhadoop(this.props.params.jobId);
-    return _.find(this.props.jobs, (d) => lolhadoop(d.id) == jobId);
+    return _.find(this.props.jobs, (d) => lolhadoop(d.id) == jobId); // eslint-disable-line eqeqeq
   }
 
   render() {
@@ -31,7 +31,7 @@ export default class extends React.Component {
       const errorBody = p[0].split('\n').slice(1).join('\n');
       return (
         <dl>
-          <dt>{attempts.length} time{attempts.length == 1 ? '' : 's'}</dt>
+          <dt>{attempts.length} time{attempts.length === 1 ? '' : 's'}</dt>
           <pre>
             <b>{errorMessage}</b><br />
             {errorBody}

--- a/js/jobrow.jsx
+++ b/js/jobrow.jsx
@@ -26,7 +26,7 @@ class JobRow extends React.Component {
 
   render() {
     const columns = this.columns();
-    return <tr onClick={this.handleOnClick}>{columns.map((d, i) => <td key={i}>{d}</td>)}</tr>;
+    return <tr onClick={this.handleOnClick}>{columns.map((d, i) => <td key={i}>{d}</td>)}</tr>; // eslint-disable-line react/no-array-index-key
   }
 }
 

--- a/js/list.jsx
+++ b/js/list.jsx
@@ -35,7 +35,7 @@ export default class extends React.Component {
   componentWillReceiveProps(nextProps) {
     // A change to the filter when we're flushed indicates a legit transition, probably via browser
     // back button. If we're not flushed then it's just the location bar catching up to our state.
-    if (this.state.flushed && this.state.filter != nextProps.location.query.filter) {
+    if (this.state.flushed && this.state.filter != nextProps.location.query.filter) { // eslint-disable-line eqeqeq
       this.setState({filter: nextProps.location.query.filter || ''});
     }
   }

--- a/js/list.jsx
+++ b/js/list.jsx
@@ -46,16 +46,13 @@ export default class extends React.Component {
   }
 
   render() {
-    console.time('BigData');
     const {jobs} = this.props;
     const filter = this.state.filter.toLowerCase();
-    const rv = (
+    return (
       <div>
         <RunningJobs jobs={jobs} query={this.props.location.query} onFilter={this.handleOnFilter} filter={filter} />
         <FinishedJobs jobs={jobs} query={this.props.location.query} onFilter={this.handleOnFilter} filter={filter} />
       </div>
     );
-    console.timeEnd('BigData');
-    return rv;
   }
 }

--- a/js/mr.jsx
+++ b/js/mr.jsx
@@ -84,7 +84,7 @@ export class MRTask {
     this.startTime = start ? new Date(start) : new Date();
     this.startTime.setMilliseconds(0);
     this.finishTime = finish ? new Date(finish) : null;
-    this.bogus = start == -1;
+    this.bogus = start == -1; // eslint-disable-line eqeqeq
   }
 
   duration() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timberlake",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Timberlake is a Job Tracker for Hadoop.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/stripe/timberlake/pull/71/commits/948a7d1fbeb8a53e29f9aadf83caa9d9229a58d0 that would prevent Waterfalls and BoxPlots from rendering correctly. The fix is taken from https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md

This also means we no longer need to override the `class-methods-use-this` 🎉 

Also:
- Add disables for remaining eslint violations
- Bump `package.json` release version (though i'm not sure that matters b/c this isn't an npm module)
- Kills the `console.time` spam
- Fixes an invalid CSS property value (though it doesn't seem to matter visually)

Tested by deploying to edge. Ideally this would include programmatic tests but we're not quiiite there yet.

r? @stripe/data-platform 