### PR TITLE
Make namenodeAddress part of jobTracker struct

### DIFF
--- a/history.go
+++ b/history.go
@@ -358,7 +358,7 @@ func findHistoryAndConfFiles(client *hdfs.Client, jobID jobID, finishTime int64)
 func (jt *jobTracker) updateFromHistoryFile(job *job, full bool) error {
 	now := time.Now()
 
-	client, err := hdfs.New(*namenodeAddress)
+	client, err := hdfs.New(jt.namenodeAddress)
 	if err != nil {
 		return err
 	}

--- a/jobtracker.go
+++ b/jobtracker.go
@@ -90,18 +90,20 @@ type jobTracker struct {
 	rm       string
 	hs       string
 	ps       string
+	namenodeAddress string
 	running  chan *job
 	finished chan *job
 	backfill chan *job
 	updates  chan *job
 }
 
-func newJobTracker(rmHost string, historyHost string, proxyHost string) *jobTracker {
+func newJobTracker(rmHost string, historyHost string, proxyHost string, namenodeAddress string) *jobTracker {
 	return &jobTracker{
 		jobs:     make(map[jobID]*job),
 		rm:       rmHost,
 		hs:       historyHost,
 		ps:       proxyHost,
+		namenodeAddress: namenodeAddress,
 		running:  make(chan *job),
 		finished: make(chan *job),
 		backfill: make(chan *job),

--- a/logs.go
+++ b/logs.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (jt *jobTracker) testLogsDir() error {
-	client, err := hdfs.New(*namenodeAddress)
+	client, err := hdfs.New(jt.namenodeAddress)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 		proxyServerURL = resourceManagerURL
 	}
 
-	jt = newJobTracker(*resourceManagerURL, *historyServerURL, *proxyServerURL)
+	jt = newJobTracker(*resourceManagerURL, *historyServerURL, *proxyServerURL, *namenodeAddress)
 	go jt.Loop()
 
 	if err := jt.testLogsDir(); err != nil {


### PR DESCRIPTION
Moves `namenodeAddress` into the `jobTracker` `struct`. This allows us to support multiple `jobTracker`s with distinct `namenodeAddress`es.

Tested via edge deploy.

r? @stripe/data-platform 