### PR TITLE
Add golint to test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go: 1.6
 script: make test
 before_deploy: make release
+before_install: go get github.com/golang/lint/golint
 deploy:
   provider: releases
   api_key:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ RUN if [ -e /usr/stripe/bin/docker/stripe-install-node ]; then /usr/stripe/bin/d
 
 ADD . /go/src/github.com/stripe/timberlake
 RUN mkdir -p /build/
+RUN go get -v github.com/golang/lint/golint
 WORKDIR /go/src/github.com/stripe/timberlake
 CMD /go/src/github.com/stripe/timberlake/jenkins_build.sh

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ all: test build
 
 test: node_modules
 	npm run test
+	golint -set_exit_status
 	go test -race
 
 build: bin/timberlake bin/timberlake-slackbot static

--- a/history.go
+++ b/history.go
@@ -156,24 +156,24 @@ func (jp *jhistParser) parse() error {
 		case "MAP_ATTEMPT_STARTED":
 			jp.parseTaskStarted(wrapper.Event)
 		case "MAP_ATTEMPT_FINISHED":
-			jp.job.Details.MapsCompleted += 1
+			jp.job.Details.MapsCompleted++
 			jp.parseMapFinished(wrapper.Event)
 		case "MAP_ATTEMPT_FAILED":
-			jp.job.Details.MapsFailed += 1
+			jp.job.Details.MapsFailed++
 			jp.parseTaskFailed(wrapper.Event)
 		case "MAP_ATTEMPT_KILLED":
-			jp.job.Details.MapsKilled += 1
+			jp.job.Details.MapsKilled++
 			jp.parseTaskFailed(wrapper.Event)
 		case "REDUCE_ATTEMPT_STARTED":
 			jp.parseTaskStarted(wrapper.Event)
 		case "REDUCE_ATTEMPT_FINISHED":
-			jp.job.Details.ReducesCompleted += 1
+			jp.job.Details.ReducesCompleted++
 			jp.parseReduceFinished(wrapper.Event)
 		case "REDUCE_ATTEMPT_FAILED":
-			jp.job.Details.ReducesFailed += 1
+			jp.job.Details.ReducesFailed++
 			jp.parseTaskFailed(wrapper.Event)
 		case "REDUCE_ATTEMPT_KILLED":
-			jp.job.Details.ReducesKilled += 1
+			jp.job.Details.ReducesKilled++
 			jp.parseTaskFailed(wrapper.Event)
 		}
 

--- a/jobtracker.go
+++ b/jobtracker.go
@@ -230,7 +230,7 @@ func (jt *jobTracker) finishedJobLoop() {
 		log.Println("Finished backfilling jobs.")
 	}()
 
-	for _ = range time.Tick(*pollInterval) {
+	for range time.Tick(*pollInterval) {
 		dur := 1 * time.Minute
 		if dur < (*pollInterval * 2) {
 			dur = *pollInterval * 2
@@ -259,7 +259,7 @@ func (jt *jobTracker) finishedJobLoop() {
 }
 
 func (jt *jobTracker) cleanupLoop() {
-	for _ = range time.Tick(time.Second * 60) {
+	for range time.Tick(time.Second * 60) {
 		jt.jobsLock.Lock()
 
 		details := make(jobDetails, 0)

--- a/jobtracker.go
+++ b/jobtracker.go
@@ -54,7 +54,7 @@ func hadoopIDs(id string) (string, jobID) {
 var httpClient = http.Client{
 	Timeout: *httpTimeout,
 	CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		return fmt.Errorf("No redirects allowed. Blocked redirect to %s.", req.URL)
+		return fmt.Errorf("no redirects allowed. Blocked redirect to %s", req.URL)
 	},
 }
 
@@ -69,7 +69,7 @@ func getJSON(url string, data interface{}) error {
 	}
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("Failed getJSON: %v (%v)", url, resp.Status)
+		return fmt.Errorf("failed getJSON: %v (%v)", url, resp.Status)
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
Adds `golint` to the the test suite to ensure go code is idiomatic. (This is sliiightly inconsistent with eslint settings though, for instance the former requires unary increment/decrement operators, while the latter forbids them.)

r? @stripe/data-platform 