### PR TITLE
Upgrade some npm packages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,7 @@ gulp.task('copy', function() {
 
 gulp.task('babel', function() {
   return browserify({entries: 'js/app.jsx', extensions: ['.jsx'], debug: true})
-    .transform('babelify', {presets: ['es2015', 'react']})
+    .transform('babelify', {presets: ['env', 'react']})
     .bundle()
     .pipe(source('bundle.js'))
     .pipe(gulp.dest('static/js'));

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "babel-eslint": "^8.0.1",
     "babel-plugin-transform-es2015-modules-amd": "^6.18.0",
-    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.16.0",
     "babelify": "^7.3.0",
     "browserify": "^13.3.0",
@@ -23,7 +23,6 @@
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-stripe": "^1.2.0",
     "gulp": "^3.9.1",
-    "gulp-react": "^2.0.0",
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-router": "^3.0.2"
   },
   "main": "gulpfile.js",


### PR DESCRIPTION
This change primarily upgrades `react` and `react-dom` from 15.4.2 to 16.0.0. This is to hopefully unblock some issues when attempting to use `PropTypes`, but there's lots of good stuff in the release notes so it should be worth it regardless: https://reactjs.org/blog/2017/09/26/react-v16.0.html

This also makes the switch from `babel-preset-es2015` to `babel-preset-env`. See http://babeljs.io/env for details.

Finally this removes the `gulp-react` entry, as the dependency was dropped in https://github.com/stripe/timberlake/commit/67a509697f09a0d3e00460e830d9fa926697965c.

Tested via edge deploy.

r? @stripe/data-platform 