### PR TITLE
Update RM url when it becomes standby

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -67,7 +67,7 @@ func (jt *jobTracker) fetchConf(id string) (map[string]string, error) {
 	appID, jobID := hadoopIDs(id)
 	url := fmt.Sprintf("%s/proxy/%s/ws/v1/mapreduce/jobs/%s/conf", jt.rm, appID, jobID)
 	confResp := &confResp{}
-	if err := getJSON(url, confResp); err != nil {
+	if _, err := getJSON(url, confResp); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This lays the foundation for updating a JobTracker's RM url when it becomes the standby. Currently, when this happens, requests the url indicates it will redirect, but does not appear to so. Since the redirect url is in the response, we can regexp parse it and update the JT's url accordingly. It's hella sketchy, and possibly fixed by upgrading Hadoop versions, but still preferable to having to make a service config change and re-deploying.

There are definitely more sensible/logical ways to organize the code than shoehorning the JT into the JSON request code, but i'd like to roll with this as the initial attempt.

(Note this code is just a dry-run to make sure we're parsing the url correctly.)

r? @tchow-stripe 
cc @stripe/data-platform 