### PR TITLE
Add multicluster support

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,11 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+
+[strict]

--- a/history.go
+++ b/history.go
@@ -367,7 +367,7 @@ func (jt *jobTracker) updateFromHistoryFile(job *job, full bool) error {
 	_, jobID := hadoopIDs(job.Details.ID)
 	confFile, histFile, err := findHistoryAndConfFiles(client, jobID, job.Details.FinishTime)
 	if err != nil {
-		return fmt.Errorf("couldn't find history file for %s: %s", jobID, err)
+		return fmt.Errorf("couldn't find history file for %s in cluster %s: %s", jobID, jt.clusterName, err)
 	}
 
 	histFileReader, err := client.Open(histFile)

--- a/job.go
+++ b/job.go
@@ -21,11 +21,6 @@ type job struct {
 	Cluster  string    `json:"cluster"`
 }
 
-type jobCluster struct {
-	Cluster	string `json:"cluster"`
-	Jobs    []*job  `json:"jobs"`
-}
-
 type jobDetail struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`

--- a/job.go
+++ b/job.go
@@ -18,6 +18,12 @@ type job struct {
 	running  bool
 	partial  bool
 	updated  time.Time
+	Cluster  string    `json:"cluster"`
+}
+
+type jobCluster struct {
+	Cluster	string `json:"cluster"`
+	Jobs    []*job  `json:"jobs"`
 }
 
 type jobDetail struct {

--- a/jobtracker.go
+++ b/jobtracker.go
@@ -24,7 +24,7 @@ const (
 
 	// Maximum number of jobs to keep track of. All data is retained in memory
 	// on the server, and the details for each job are sent to the browser.
-	jobLimit = 5000
+	jobLimit = 10000
 
 	// How many hours of history should we ask for from the job server?
 	jobHistoryDuration = time.Hour * 24 * 7

--- a/jobtracker.go
+++ b/jobtracker.go
@@ -22,9 +22,10 @@ const (
 	// primarily useful during the initial data backfill.
 	finishedJobWorkers = 3
 
-	// Maximum number of jobs to keep track of. All data is retained in memory
-	// on the server, and the details for each job are sent to the browser.
-	jobLimit = 10000
+	// Maximum number of jobs to keep track of per cluster. All data is retained
+	// in memory on the server, and the details for each job are sent to the
+	// browser.
+	jobLimit = 5000
 
 	// How many hours of history should we ask for from the job server?
 	jobHistoryDuration = time.Hour * 24 * 7
@@ -511,6 +512,7 @@ func (jt *jobTracker) fetchCounters(id string) ([]counter, error) {
 
 func (jt *jobTracker) sendUpdates(sse *sse) {
 	for job := range jt.updates {
+		// FIXME: set the cluster in a more intuitive place, not JIT
 		job.Cluster = jt.clusterName
 		jsonBytes, err := json.Marshal(job)
 		if err != nil {

--- a/jobtracker.go
+++ b/jobtracker.go
@@ -128,6 +128,7 @@ func (jt *jobTracker) Loop() {
 }
 
 func (jt *jobTracker) runningJobLoop() {
+	log.Println("Initiating runningJobLoop for cluster:", jt.clusterName)
 	for x := 1; x <= runningJobWorkers; x++ {
 		go func() {
 			for job := range jt.running {
@@ -140,25 +141,29 @@ func (jt *jobTracker) runningJobLoop() {
 					// why we're here and let the mostly-empty job data
 					// propagate anyways.
 					if jt.hasJob(job.Details.ID) {
+						log.Printf("%s has job %s, continuing", jt.clusterName, job.Details.ID)
 						continue
 					}
 				}
 
+				log.Printf("%s: saving job %s", jt.clusterName, job.Details.ID)
 				jt.saveJob(job)
+				log.Printf("%s: saved job %s", jt.clusterName, job.Details.ID)
 				jt.updates <- job
+				log.Printf("%s: sent job %s to updated channel", jt.clusterName, job.Details.ID)
 			}
 		}()
 	}
 
 	for range time.Tick(*pollInterval) {
-		log.Printf("Listing running jobs on resource manager %s\n", jt.rm)
+		log.Printf("Begin listing running jobs in cluster %s on resource manager %s\n", jt.clusterName, jt.rm)
 		running, err := jt.listJobs()
 		if err != nil {
 			log.Println("Error listing running jobs:", err)
 			continue
 		}
 
-		log.Println("Running jobs:", len(running.Apps.App))
+		log.Printf("Running jobs in cluster %s: %d\n", jt.clusterName, len(running.Apps.App))
 		log.Println("Jobs in cache:", len(jt.jobs))
 		log.Println("Goroutines:", runtime.NumGoroutine())
 
@@ -168,17 +173,21 @@ func (jt *jobTracker) runningJobLoop() {
 		// doesn't know what GONE means so it ignores the job.
 		for jobID, job := range jt.jobs {
 			if job.running && time.Now().Sub(job.updated).Seconds() > 30*pollInterval.Seconds() {
-				log.Printf("%s has not been updated in thirty ticks. Removing.", jobID)
+				log.Printf("%s in cluster %s has not been updated in thirty ticks. Removing.\n", jobID, jt.clusterName)
 				job.Details.State = "GONE"
 				jt.updates <- job
 				jt.deleteJob(job.Details.ID)
 			}
 		}
-
+		log.Printf("%s: appending running jobs\n", jt.clusterName)
 		for i := range running.Apps.App {
+			log.Printf("%s: will append running job %s\n", jt.clusterName, running.Apps.App[i].ID)
 			job := &job{Details: running.Apps.App[i], running: true, updated: time.Now()}
+			log.Printf("%s: appending running job %s\n", jt.clusterName, job.Details.ID)
 			jt.running <- job
+			log.Printf("%s: appended running job %s\n", jt.clusterName, job.Details.ID)
 		}
+		log.Printf("Done listing running jobs in cluster %s on resource manager %s\n", jt.clusterName, jt.rm)
 	}
 
 }

--- a/js/JobTable.jsx
+++ b/js/JobTable.jsx
@@ -60,6 +60,7 @@ class JobTable extends React.Component {
     const sortDir = `sort-${sort.dir > 0 ? 'asc' : 'desc'}`;
     const Row = this.rowClass();
     const rows = jobs.slice(0, 150).map((job) => <Row key={job.id} job={job} />);
+    /* eslint-disable react/jsx-no-bind */
     return (
       <div>
         <h3>
@@ -77,7 +78,7 @@ class JobTable extends React.Component {
             <tr>
               {this.headers.map((h) => {
                 const cls = sort.key === h ? sortDir : '';
-                const click = this.sort.bind(this, h); // eslint-disable-line react/jsx-no-bind
+                const click = this.sort.bind(this, h);
                 return <th key={h} className={cls} onClick={click}>{h}</th>;
               })}
             </tr>
@@ -86,6 +87,7 @@ class JobTable extends React.Component {
         </table>
       </div>
     );
+    /* eslint-enable react/njsx-no-bind */
   }
 }
 

--- a/js/JobTable.jsx
+++ b/js/JobTable.jsx
@@ -8,7 +8,6 @@ import {
 
 const {_} = window;
 
-// TODO: only display the cluster column when there are multiple clusters
 const HEADERS = ['user', 'name', 'started', 'duration', 'map', 'reduce', 'cluster'];
 
 class JobTable extends React.Component {
@@ -56,10 +55,13 @@ class JobTable extends React.Component {
   }
 
   render() {
+    const {isMulticluster} = this.props;
     const [sort, jobs] = this.sortedJobs();
     const sortDir = `sort-${sort.dir > 0 ? 'asc' : 'desc'}`;
     const Row = this.rowClass();
-    const rows = jobs.slice(0, 150).map((job) => <Row key={job.id} job={job} />);
+    const rows = jobs.slice(0, 150).map((job) =>
+      <Row isMulticluster={isMulticluster} key={job.id} job={job} />);
+    const headers = isMulticluster ? this.headers : this.headers.slice(0, -1);
     /* eslint-disable react/jsx-no-bind */
     return (
       <div>
@@ -76,7 +78,7 @@ class JobTable extends React.Component {
         <table className="table sortable list-view">
           <thead>
             <tr>
-              {this.headers.map((h) => {
+              {headers.map((h) => {
                 const cls = sort.key === h ? sortDir : '';
                 const click = this.sort.bind(this, h);
                 return <th key={h} className={cls} onClick={click}>{h}</th>;

--- a/js/JobTable.jsx
+++ b/js/JobTable.jsx
@@ -4,10 +4,12 @@ import {FinishedJobRow, RunningJobRow} from './jobrow';
 import {
   ACTIVE_STATES,
   FINISHED_STATES,
-  HEADERS,
 } from './utils';
 
 const {_} = window;
+
+// TODO: only display the cluster column when there are multiple clusters
+const HEADERS = ['user', 'name', 'started', 'duration', 'map', 'reduce', 'cluster'];
 
 class JobTable extends React.Component {
   static sorting(sort) {
@@ -73,7 +75,7 @@ class JobTable extends React.Component {
         <table className="table sortable list-view">
           <thead>
             <tr>
-              {HEADERS.map((h) => {
+              {this.headers.map((h) => {
                 const cls = sort.key === h ? sortDir : '';
                 const click = this.sort.bind(this, h); // eslint-disable-line react/jsx-no-bind
                 return <th key={h} className={cls} onClick={click}>{h}</th>;
@@ -95,6 +97,7 @@ export class FinishedJobs extends JobTable {
     this.states = FINISHED_STATES;
     this.defaultSortKey = '-finished';
     this.title = 'Finished';
+    this.headers = HEADERS;
     this.rowClass = () => FinishedJobRow;
   }
 }
@@ -107,6 +110,7 @@ export class RunningJobs extends JobTable {
     this.states = ACTIVE_STATES;
     this.defaultSortKey = '-started';
     this.title = 'Running';
+    this.headers = HEADERS;
     this.rowClass = () => RunningJobRow;
     this.autoFocus = true;
   }

--- a/js/JobTable.jsx
+++ b/js/JobTable.jsx
@@ -4,11 +4,10 @@ import {FinishedJobRow, RunningJobRow} from './jobrow';
 import {
   ACTIVE_STATES,
   FINISHED_STATES,
+  HEADERS,
 } from './utils';
 
 const {_} = window;
-
-const HEADERS = ['user', 'name', 'started', 'duration', 'map', 'reduce', 'cluster'];
 
 class JobTable extends React.Component {
   static sorting(sort) {
@@ -74,7 +73,7 @@ class JobTable extends React.Component {
         <table className="table sortable list-view">
           <thead>
             <tr>
-              {this.headers.map((h) => {
+              {HEADERS.map((h) => {
                 const cls = sort.key === h ? sortDir : '';
                 const click = this.sort.bind(this, h); // eslint-disable-line react/jsx-no-bind
                 return <th key={h} className={cls} onClick={click}>{h}</th>;
@@ -96,7 +95,6 @@ export class FinishedJobs extends JobTable {
     this.states = FINISHED_STATES;
     this.defaultSortKey = '-finished';
     this.title = 'Finished';
-    this.headers = HEADERS;
     this.rowClass = () => FinishedJobRow;
   }
 }
@@ -109,7 +107,6 @@ export class RunningJobs extends JobTable {
     this.states = ACTIVE_STATES;
     this.defaultSortKey = '-started';
     this.title = 'Running';
-    this.headers = HEADERS;
     this.rowClass = () => RunningJobRow;
     this.autoFocus = true;
   }

--- a/js/JobTable.jsx
+++ b/js/JobTable.jsx
@@ -8,7 +8,7 @@ import {
 
 const {_} = window;
 
-const HEADERS = ['user', 'name', 'started', 'duration', 'map', 'reduce'];
+const HEADERS = ['user', 'name', 'started', 'duration', 'map', 'reduce', 'cluster'];
 
 class JobTable extends React.Component {
   static sorting(sort) {
@@ -18,7 +18,7 @@ class JobTable extends React.Component {
 
   sort(key) {
     const s = JobTable.sorting(this.props.query[this.sortKey] || this.defaultSortKey);
-    const n = s.key == key && s.dir == -1 ? key : `-${key}`; // eslint-disable-line eqeqeq
+    const n = s.key === key && s.dir === -1 ? key : `-${key}`;
     const q = _.object([[this.sortKey, n]]);
 
     hashHistory.push({
@@ -46,10 +46,11 @@ class JobTable extends React.Component {
         case 'map': return row.maps.progress;
         case 'reduce': return row.reduces.progress;
         case 'state': return row.state;
+        case 'cluster': return row.cluster;
         default: return undefined;
       }
     });
-    if (sort.dir == -1) jobs.reverse(); // eslint-disable-line eqeqeq
+    if (sort.dir === -1) jobs.reverse();
     return [sort, jobs];
   }
 
@@ -74,7 +75,7 @@ class JobTable extends React.Component {
           <thead>
             <tr>
               {this.headers.map((h) => {
-                const cls = sort.key == h ? sortDir : ''; // eslint-disable-line eqeqeq
+                const cls = sort.key === h ? sortDir : '';
                 const click = this.sort.bind(this, h); // eslint-disable-line react/jsx-no-bind
                 return <th key={h} className={cls} onClick={click}>{h}</th>;
               })}

--- a/js/app.jsx
+++ b/js/app.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {render} from 'react-dom';
 import {Router, Route, IndexRoute, hashHistory} from 'react-router';
 
-import BigData from './list';
+import List from './list';
 import Job from './job';
 import JobLogs from './joblogs';
 import JobConf from './components/JobConf';
@@ -25,11 +25,17 @@ class App extends React.Component {
     super(props);
 
     this.state = {
+      isMulticluster: false,
       jobs: {},
     };
   }
 
   componentDidMount() {
+    Store.on('numClusters', (numClusters) => {
+      this.setState({isMulticluster: numClusters > 1});
+    });
+    Store.getNumClusters();
+
     Store.on('job', (job) => {
       this.updates[job.id] = job;
     });
@@ -79,12 +85,14 @@ class App extends React.Component {
   }
 
   render() {
+    const {isMulticluster} = this.state;
     const jobs = _.values(this.state.jobs);
     return (
       <div>
         <NavBar jobs={jobs} />
         <div id="main" className="container">
           {this.props.children && React.cloneElement(this.props.children, {
+            isMulticluster,
             jobs,
           })}
         </div>
@@ -96,7 +104,7 @@ class App extends React.Component {
 render(
   <Router history={hashHistory}>
     <Route path="/" component={App}>
-      <IndexRoute component={BigData} />
+      <IndexRoute component={List} />
       <Route name="job" path="job/:jobId" component={Job} />
       <Route name="log" path="job/:jobId/logs" component={JobLogs} />
       <Route name="cfg" path="job/:jobId/conf" component={JobConf} />

--- a/js/app.jsx
+++ b/js/app.jsx
@@ -15,7 +15,7 @@ const {_} = window;
 /**
  * Number of most recent jobs to keep in the finished tab.
  */
-const JOBS_TO_KEEP = 5000;
+const JOBS_TO_KEEP = 10000;
 
 /**
  * Component responsible for the application state.

--- a/js/components/JobConf.jsx
+++ b/js/components/JobConf.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 
@@ -55,7 +54,3 @@ export default class JobConf extends React.Component {
     );
   }
 }
-
-JobConf.propTypes = {
-  params: PropTypes.shape({jobId: PropTypes.string.isRequired}).isRequired,
-};

--- a/js/components/Waterfall.jsx
+++ b/js/components/Waterfall.jsx
@@ -14,7 +14,7 @@ function waterfall(data, node, optsIn) {
     textFormat: (t) => '',
     linkFormat: null,
     fillStyle: (d) => {
-      return d.type == 'map' ? COLOUR_MAP : COLOUR_REDUCE; // eslint-disable-line eqeqeq
+      return d.type === 'map' ? COLOUR_MAP : COLOUR_REDUCE;
     },
   };
   const opts = _.extend(defaults, optsIn);

--- a/js/job.jsx
+++ b/js/job.jsx
@@ -288,28 +288,30 @@ export default class Job extends React.Component {
   }
 }
 
+export const JOB_PROP_TYPES = {
+  cluster: PropTypes.string.isRequired,
+  conf: PropTypes.object.isRequired,
+  counters: PropTypes.object.isRequired,
+  finishTime: PropTypes.instanceOf(Date),
+  fullName: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+  maps: PropTypes.object.isRequired,
+  name: PropTypes.string.isRequired,
+  reduces: PropTypes.object.isRequired,
+  searchstring: PropTypes.string,
+  startTime: PropTypes.instanceOf(Date).isRequired,
+  state: PropTypes.oneOf(VALID_STATES).isRequired,
+  taskFamily: PropTypes.string,
+  tasks: PropTypes.object.isRequired,
+  user: PropTypes.string.isRequired,
+};
+
 Job.defaultProps = {
   jobs: [],
 };
 
 Job.propTypes = {
-  jobs: PropTypes.arrayOf(PropTypes.shape({
-    cluster: PropTypes.string.isRequired,
-    conf: PropTypes.object.isRequired,
-    counters: PropTypes.object.isRequired,
-    finishTime: PropTypes.instanceOf(Date),
-    fullName: PropTypes.string.isRequired,
-    id: PropTypes.string.isRequired,
-    maps: PropTypes.object.isRequired,
-    name: PropTypes.string.isRequired,
-    reduces: PropTypes.object.isRequired,
-    searchstring: PropTypes.string,
-    startTime: PropTypes.instanceOf(Date).isRequired,
-    state: PropTypes.oneOf(VALID_STATES).isRequired,
-    taskFamily: PropTypes.string,
-    tasks: PropTypes.object.isRequired,
-    user: PropTypes.string.isRequired,
-  }).isRequired),
+  jobs: PropTypes.arrayOf(PropTypes.shape(JOB_PROP_TYPES).isRequired),
   params: PropTypes.shape({
     jobId: PropTypes.string.isRequired,
   }).isRequired,

--- a/js/job.jsx
+++ b/js/job.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 import ReactTooltip from 'react-tooltip';
@@ -18,6 +19,7 @@ import {
   lolhadoop,
   secondFormat,
   timeFormat,
+  VALID_STATES,
 } from './utils';
 import {notAvailable} from './mr';
 
@@ -285,3 +287,30 @@ export default class Job extends React.Component {
     );
   }
 }
+
+Job.defaultProps = {
+  jobs: [],
+};
+
+Job.propTypes = {
+  jobs: PropTypes.arrayOf(PropTypes.shape({
+    cluster: PropTypes.string.isRequired,
+    conf: PropTypes.object.isRequired,
+    counters: PropTypes.object.isRequired,
+    finishTime: PropTypes.instanceOf(Date),
+    fullName: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    maps: PropTypes.object.isRequired,
+    name: PropTypes.string.isRequired,
+    reduces: PropTypes.object.isRequired,
+    searchstring: PropTypes.string,
+    startTime: PropTypes.instanceOf(Date).isRequired,
+    state: PropTypes.oneOf(VALID_STATES).isRequired,
+    taskFamily: PropTypes.string,
+    tasks: PropTypes.object.isRequired,
+    user: PropTypes.string.isRequired,
+  }).isRequired),
+  params: PropTypes.shape({
+    jobId: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/js/job.jsx
+++ b/js/job.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
-import React from 'react';
+// @flow
+import * as React from 'react';
 import {Link} from 'react-router';
 import ReactTooltip from 'react-tooltip';
 
@@ -19,7 +19,6 @@ import {
   lolhadoop,
   secondFormat,
   timeFormat,
-  VALID_STATES,
 } from './utils';
 import {notAvailable} from './mr';
 
@@ -53,10 +52,28 @@ function relatedJobs(job, allJobs) {
   return [];
 }
 
-export default class Job extends React.Component {
-  constructor(props) {
+type Props = {
+  jobs: any,
+  params: Object,
+};
+
+type State = {
+  hover: boolean,
+  jobConfs: Object,
+  killing: boolean,
+  killResult?: any,
+  showKillModal: boolean,
+}
+
+export default class Job extends React.Component<Props, State> {
+  constructor(props: any) {
     super(props);
-    this.state = {jobConfs: {}};
+    this.state = {
+      hover: false,
+      jobConfs: {},
+      killing: false,
+      showKillModal: false,
+    };
 
     this.kill = this.kill.bind(this);
     this.handleShowKillModal = this.handleShowKillModal.bind(this);
@@ -79,7 +96,7 @@ export default class Job extends React.Component {
     this.handleNewJobID(this.props.params.jobId);
   }
 
-  componentWillReceiveProps(next) {
+  componentWillReceiveProps(next: any) {
     if (this.props.params.jobId !== next.params.jobId) {
       this.handleNewJobID(next.params.jobId);
     }
@@ -90,7 +107,11 @@ export default class Job extends React.Component {
     return _.find(this.props.jobs, (d) => lolhadoop(d.id) === jobId);
   }
 
-  handleNewJobID(jobId) {
+  kill: Function;
+  handleShowKillModal: Function;
+  handleHideKillModal: Function;
+
+  handleNewJobID(jobId: string) {
     Store.getJob(jobId);
     ConfStore.getJobConf(jobId);
     relatedJobs(this.getJob(), this.props.jobs).forEach((job) => {
@@ -132,7 +153,7 @@ export default class Job extends React.Component {
     /* eslint-disable react/no-array-index-key */
     const renderedInputs = (
       <ul className="list-unstyled">
-        {inputs(job, this.props.jobs, conf, this.state.jobConfs).map((input, i) =>
+        {inputs(job, this.props.jobs, conf, this.state.jobConfs).map((input: any, i) =>
           (
             <li key={i}>
               {_.isString(input) ?
@@ -202,7 +223,17 @@ export default class Job extends React.Component {
       pairs.push(['Line Numbers', steps]);
     }
 
-    const bytes = {
+    const bytes: {
+      file_read: any,
+      file_written: any,
+      hdfs_read: any,
+      hdfs_written: any,
+      s3_read: any,
+      s3_written: any,
+      shuffled: any,
+      total_read?: any,
+      total_written?: any,
+    } = {
       hdfs_read: job.counters.get('FileSystemCounter.HDFS_BYTES_READ').map,
       s3_read: job.counters.get('FileSystemCounter.S3_BYTES_READ').map || 0,
       file_read: job.counters.get('FileSystemCounter.FILE_BYTES_READ').map || 0,
@@ -287,32 +318,3 @@ export default class Job extends React.Component {
     );
   }
 }
-
-export const JOB_PROP_TYPES = {
-  cluster: PropTypes.string.isRequired,
-  conf: PropTypes.object.isRequired,
-  counters: PropTypes.object.isRequired,
-  finishTime: PropTypes.instanceOf(Date),
-  fullName: PropTypes.string.isRequired,
-  id: PropTypes.string.isRequired,
-  maps: PropTypes.object.isRequired,
-  name: PropTypes.string.isRequired,
-  reduces: PropTypes.object.isRequired,
-  searchstring: PropTypes.string,
-  startTime: PropTypes.instanceOf(Date).isRequired,
-  state: PropTypes.oneOf(VALID_STATES).isRequired,
-  taskFamily: PropTypes.string,
-  tasks: PropTypes.object.isRequired,
-  user: PropTypes.string.isRequired,
-};
-
-Job.defaultProps = {
-  jobs: [],
-};
-
-Job.propTypes = {
-  jobs: PropTypes.arrayOf(PropTypes.shape(JOB_PROP_TYPES).isRequired),
-  params: PropTypes.shape({
-    jobId: PropTypes.string.isRequired,
-  }).isRequired,
-};

--- a/js/jobrow.jsx
+++ b/js/jobrow.jsx
@@ -1,10 +1,7 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import {Link, hashHistory} from 'react-router';
 
-import {JOB_PROP_TYPES} from './job';
 import {
-  HEADERS,
   timeFormat,
   secondFormat,
   jobState,
@@ -29,17 +26,9 @@ class JobRow extends React.Component {
 
   render() {
     const columns = this.columns();
-    return (
-      <tr onClick={this.handleOnClick}>
-        {columns.map((d, i) => <td key={HEADERS[i]}>{d}</td>)}
-      </tr>
-    );
+    return <tr onClick={this.handleOnClick}>{columns.map((d, i) => <td key={i}>{d}</td>)}</tr>; // eslint-disable-line react/no-array-index-key
   }
 }
-
-JobRow.propTypes = {
-  job: PropTypes.shape(JOB_PROP_TYPES).isRequired,
-};
 
 export class RunningJobRow extends JobRow {
   columns() {

--- a/js/jobrow.jsx
+++ b/js/jobrow.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Link, hashHistory} from 'react-router';
 
 import {
+  HEADERS,
   timeFormat,
   secondFormat,
   jobState,
@@ -26,7 +27,11 @@ class JobRow extends React.Component {
 
   render() {
     const columns = this.columns();
-    return <tr onClick={this.handleOnClick}>{columns.map((d, i) => <td key={i}>{d}</td>)}</tr>; // eslint-disable-line react/no-array-index-key
+    return (
+      <tr onClick={this.handleOnClick}>
+        {columns.map((d, i) => <td key={HEADERS[i]}>{d}</td>)}
+      </tr>
+    );
   }
 }
 

--- a/js/jobrow.jsx
+++ b/js/jobrow.jsx
@@ -32,30 +32,32 @@ class JobRow extends React.Component {
 
 export class RunningJobRow extends JobRow {
   columns() {
-    const {job} = this.props;
-    return [
+    const {isMulticluster, job} = this.props;
+    const row = [
       job.user,
       <Link to={`/job/${job.id}`}>{job.name}</Link>,
       timeFormat(job.startTime),
       secondFormat(job.duration()),
       <ProgressBar value={job.maps.progress} />,
       <ProgressBar value={job.reduces.progress} />,
-      job.cluster,
     ];
+    if (isMulticluster) { row.push(job.cluster); }
+    return row;
   }
 }
 
 export class FinishedJobRow extends JobRow {
   columns() {
-    const {job} = this.props;
-    return [
+    const {isMulticluster, job} = this.props;
+    const row = [
       job.user,
       <Link to={`/job/${job.id}`}>{job.name}</Link>,
       timeFormat(job.startTime),
       timeFormat(job.finishTime),
       secondFormat(job.duration()),
       jobState(job),
-      job.cluster,
     ];
+    if (isMulticluster) { row.push(job.cluster); }
+    return row;
   }
 }

--- a/js/jobrow.jsx
+++ b/js/jobrow.jsx
@@ -40,6 +40,7 @@ export class RunningJobRow extends JobRow {
       secondFormat(job.duration()),
       <ProgressBar value={job.maps.progress} />,
       <ProgressBar value={job.reduces.progress} />,
+      job.cluster,
     ];
   }
 }
@@ -54,6 +55,7 @@ export class FinishedJobRow extends JobRow {
       timeFormat(job.finishTime),
       secondFormat(job.duration()),
       jobState(job),
+      job.cluster,
     ];
   }
 }

--- a/js/jobrow.jsx
+++ b/js/jobrow.jsx
@@ -1,6 +1,8 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link, hashHistory} from 'react-router';
 
+import {JOB_PROP_TYPES} from './job';
 import {
   HEADERS,
   timeFormat,
@@ -34,6 +36,10 @@ class JobRow extends React.Component {
     );
   }
 }
+
+JobRow.propTypes = {
+  job: PropTypes.shape(JOB_PROP_TYPES).isRequired,
+};
 
 export class RunningJobRow extends JobRow {
   columns() {

--- a/js/list.jsx
+++ b/js/list.jsx
@@ -4,7 +4,7 @@ import {FinishedJobs, RunningJobs} from './JobTable';
 
 const {_} = window;
 
-export default class List extends React.Component {
+export default class extends React.Component {
   constructor(props) {
     super(props);
 

--- a/js/list.jsx
+++ b/js/list.jsx
@@ -35,7 +35,7 @@ export default class extends React.Component {
   componentWillReceiveProps(nextProps) {
     // A change to the filter when we're flushed indicates a legit transition, probably via browser
     // back button. If we're not flushed then it's just the location bar catching up to our state.
-    if (this.state.flushed && this.state.filter != nextProps.location.query.filter) { // eslint-disable-line eqeqeq
+    if (this.state.flushed && this.state.filter !== nextProps.location.query.filter) {
       this.setState({filter: nextProps.location.query.filter || ''});
     }
   }
@@ -48,10 +48,18 @@ export default class extends React.Component {
   render() {
     const {jobs} = this.props;
     const filter = this.state.filter.toLowerCase();
+    const isMulticluster = (new Set(jobs.map((job) => job.cluster))).size > 1;
+    const props = {
+      filter,
+      isMulticluster,
+      jobs,
+      onFilter: this.handleOnFilter,
+      query: this.props.location.query,
+    };
     return (
       <div>
-        <RunningJobs jobs={jobs} query={this.props.location.query} onFilter={this.handleOnFilter} filter={filter} />
-        <FinishedJobs jobs={jobs} query={this.props.location.query} onFilter={this.handleOnFilter} filter={filter} />
+        <RunningJobs {...props} />
+        <FinishedJobs {...props} />
       </div>
     );
   }

--- a/js/list.jsx
+++ b/js/list.jsx
@@ -4,7 +4,7 @@ import {FinishedJobs, RunningJobs} from './JobTable';
 
 const {_} = window;
 
-export default class extends React.Component {
+export default class List extends React.Component {
   constructor(props) {
     super(props);
 

--- a/js/list.jsx
+++ b/js/list.jsx
@@ -4,7 +4,7 @@ import {FinishedJobs, RunningJobs} from './JobTable';
 
 const {_} = window;
 
-export default class extends React.Component {
+export default class List extends React.Component {
   constructor(props) {
     super(props);
 
@@ -46,9 +46,8 @@ export default class extends React.Component {
   }
 
   render() {
-    const {jobs} = this.props;
+    const {isMulticluster, jobs} = this.props;
     const filter = this.state.filter.toLowerCase();
-    const isMulticluster = (new Set(jobs.map((job) => job.cluster))).size > 1;
     const props = {
       filter,
       isMulticluster,

--- a/js/mr.js
+++ b/js/mr.js
@@ -22,7 +22,7 @@ export class MRJob {
     this.startTime.setMilliseconds(0);
     this.finishTime = d.finishTime ? new Date(d.finishTime) : null;
     this.user = d.user;
-    this.searchString = (`${this.name} ${this.user} ${this.id}`).toLowerCase();
+    this.searchString = (`${this.name} ${this.user} ${this.id} ${this.cluster}`).toLowerCase();
 
     this.maps = {
       progress: d.mapProgress || (d.mapsTotal === 0 ? notAvailable : 100 * (d.mapsCompleted / d.mapsTotal)),

--- a/js/mr.js
+++ b/js/mr.js
@@ -7,8 +7,8 @@ const {_} = window;
 export const notAvailable = {};
 
 export class MRJob {
-  constructor(data, cluster) {
-    this.cluster = cluster;
+  constructor(data) {
+    this.cluster = data.cluster;
     const d = data.details;
     this.id = d.id.replace('application_', 'job_');
     this.fullName = d.name;

--- a/js/mr.js
+++ b/js/mr.js
@@ -7,7 +7,8 @@ const {_} = window;
 export const notAvailable = {};
 
 export class MRJob {
-  constructor(data) {
+  constructor(data, cluster) {
+    this.cluster = cluster;
     const d = data.details;
     this.id = d.id.replace('application_', 'job_');
     this.fullName = d.name;
@@ -81,7 +82,7 @@ export class MRTask {
     this.startTime = start ? new Date(start) : new Date();
     this.startTime.setMilliseconds(0);
     this.finishTime = finish ? new Date(finish) : null;
-    this.bogus = start == -1; // eslint-disable-line eqeqeq
+    this.bogus = start === -1;
   }
 
   duration() {

--- a/js/store.js
+++ b/js/store.js
@@ -41,6 +41,12 @@ class JobStore {
     this.lastJob = null;
   }
 
+  getNumClusters() {
+    $.getJSON('/numClusters/').then((numClusters) => {
+      this.trigger('numClusters', numClusters);
+    }).then(null, (error) => console.error(error));
+  }
+
   getJob(id) {
     this.lastJob = id;
     $.getJSON(`/jobs/${id}`).then((data) => {

--- a/js/store.js
+++ b/js/store.js
@@ -44,23 +44,20 @@ class JobStore {
   getJob(id) {
     this.lastJob = id;
     $.getJSON(`/jobs/${id}`).then((data) => {
-      this.trigger('job', new MRJob(data, data.cluster));
+      this.trigger('job', new MRJob(data));
     }).then(null, (error) => console.error(error));
   }
 
   getJobs() {
     $.getJSON('/jobs/').then((data) => {
-      data.forEach((datum) => {
-        this.trigger('jobs', (datum.jobs || []).map((d) => new MRJob(d, datum.cluster)));
-      });
+      this.trigger('jobs', data.map((d) => new MRJob(d)));
     }).then(null, (error) => console.error(error));
   }
 
   startSSE() {
     const sse = new EventSource('/sse');
-    sse.onmessage = (event) => {
-      const data = JSON.parse(event.data);
-      this.trigger('job', new MRJob(data, data.cluster));
+    sse.onmessage = (e) => {
+      this.trigger('job', new MRJob(JSON.parse(e.data)));
     };
   }
 

--- a/js/store.js
+++ b/js/store.js
@@ -39,7 +39,6 @@ class JobStore {
   constructor() {
     this.pipes = {};
     this.lastJob = null;
-    this.eventLogs = 0;
   }
 
   getJob(id) {
@@ -61,11 +60,6 @@ class JobStore {
     const sse = new EventSource('/sse');
     sse.onmessage = (event) => {
       const data = JSON.parse(event.data);
-      if (this.eventLogs < 5) {
-        debugger; // eslint-disable-line no-debugger
-        console.log('GOT EVENT', event, data);
-        this.eventLogs += 1;
-      }
       this.trigger('job', new MRJob(data, data.cluster));
     };
   }

--- a/js/store.js
+++ b/js/store.js
@@ -39,25 +39,34 @@ class JobStore {
   constructor() {
     this.pipes = {};
     this.lastJob = null;
+    this.eventLogs = 0;
   }
 
   getJob(id) {
     this.lastJob = id;
     $.getJSON(`/jobs/${id}`).then((data) => {
-      this.trigger('job', new MRJob(data));
+      this.trigger('job', new MRJob(data, data.cluster));
     }).then(null, (error) => console.error(error));
   }
 
   getJobs() {
     $.getJSON('/jobs/').then((data) => {
-      this.trigger('jobs', data.map((d) => new MRJob(d)));
+      data.forEach((datum) => {
+        this.trigger('jobs', (datum.jobs || []).map((d) => new MRJob(d, datum.cluster)));
+      });
     }).then(null, (error) => console.error(error));
   }
 
   startSSE() {
     const sse = new EventSource('/sse');
-    sse.onmessage = (e) => {
-      this.trigger('job', new MRJob(JSON.parse(e.data)));
+    sse.onmessage = (event) => {
+      const data = JSON.parse(event.data);
+      if (this.eventLogs < 5) {
+        debugger; // eslint-disable-line no-debugger
+        console.log('GOT EVENT', event, data);
+        this.eventLogs += 1;
+      }
+      this.trigger('job', new MRJob(data, data.cluster));
     };
   }
 

--- a/js/utils.jsx
+++ b/js/utils.jsx
@@ -35,11 +35,10 @@ export function humanFormat(ms) {
   return `${numFormat(hour) + plural(hour, ' hour')} ${minute}${plural(minute, ' minute')}`;
 }
 
+
 export const ACTIVE_STATES = ['RUNNING', 'ACCEPTED'];
 export const FINISHED_STATES = ['SUCCEEDED', 'KILLED', 'FAILED', 'ERROR'];
 export const FAILED_STATES = ['FAILED', 'KILLED', 'ERROR'];
-export const VALID_STATES = ACTIVE_STATES.concat(FINISHED_STATES).concat('GONE');
-export const HEADERS = ['user', 'name', 'started', 'duration', 'map', 'reduce', 'cluster'];
 
 export function jobState(job) {
   const {state} = job;

--- a/js/utils.jsx
+++ b/js/utils.jsx
@@ -39,6 +39,7 @@ export function humanFormat(ms) {
 export const ACTIVE_STATES = ['RUNNING', 'ACCEPTED'];
 export const FINISHED_STATES = ['SUCCEEDED', 'KILLED', 'FAILED', 'ERROR'];
 export const FAILED_STATES = ['FAILED', 'KILLED', 'ERROR'];
+export const VALID_STATES = ACTIVE_STATES.concat(FINISHED_STATES).concat('GONE');
 
 export function jobState(job) {
   const {state} = job;

--- a/js/utils.jsx
+++ b/js/utils.jsx
@@ -35,11 +35,11 @@ export function humanFormat(ms) {
   return `${numFormat(hour) + plural(hour, ' hour')} ${minute}${plural(minute, ' minute')}`;
 }
 
-
 export const ACTIVE_STATES = ['RUNNING', 'ACCEPTED'];
 export const FINISHED_STATES = ['SUCCEEDED', 'KILLED', 'FAILED', 'ERROR'];
 export const FAILED_STATES = ['FAILED', 'KILLED', 'ERROR'];
 export const VALID_STATES = ACTIVE_STATES.concat(FINISHED_STATES).concat('GONE');
+export const HEADERS = ['user', 'name', 'started', 'duration', 'map', 'reduce', 'cluster'];
 
 export function jobState(job) {
   const {state} = job;

--- a/main.go
+++ b/main.go
@@ -231,21 +231,9 @@ func main() {
 		mux.Get("/debug/pprof/trace", pprof.Trace)
 	}
 
-	go func() {
-		for clusterName, jt := range jts {
-			for job := range jt.updates {
-				job.Cluster = clusterName
-				log.Printf("%s: marshalling job %s", clusterName, job.Details.ID)
-				jsonBytes, err := json.Marshal(job)
-				if err != nil {
-					log.Println("json error: ", err)
-				} else {
-					log.Printf("%s: sending marshalled job %s", clusterName, job.Details.ID)
-					sse.events <- jsonBytes
-				}
-			}
-		}
-	}()
+	for _, jt := range jts {
+		go jt.sendUpdates(sse)
+	}
 
 	http.Serve(bind.Default(), mux)
 }

--- a/main.go
+++ b/main.go
@@ -48,11 +48,11 @@ func index(c web.C, w http.ResponseWriter, r *http.Request) {
 
 func getJobs(c web.C, w http.ResponseWriter, r *http.Request) {
 	// We only need the details for listing pages.
-	var jobClusters []*jobCluster
+	var jobs []*job
 	for clusterName, tracker := range jts {
-		var jobs []*job
 		for _, j := range tracker.jobs {
 			jobs = append(jobs, &job{
+				Cluster: tracker.clusterName,
 				Details: j.Details,
 				conf: conf{
 					Input:         j.conf.Input,
@@ -63,13 +63,9 @@ func getJobs(c web.C, w http.ResponseWriter, r *http.Request) {
 			})
 		}
 		log.Printf("Appending %d jobs for Cluster %s: %s %s\n", len(jobs), clusterName, tracker.hs, tracker.rm)
-		jobClusters = append(jobClusters, &jobCluster{
-			Cluster: clusterName,
-			Jobs: jobs,
-		})
 	}
 
-	jsonBytes, err := json.Marshal(jobClusters)
+	jsonBytes, err := json.Marshal(jobs)
 	if err != nil {
 		log.Println("error:", err)
 		w.WriteHeader(500)

--- a/main.go
+++ b/main.go
@@ -235,10 +235,12 @@ func main() {
 		for clusterName, jt := range jts {
 			for job := range jt.updates {
 				job.Cluster = clusterName
+				log.Printf("%s: marshalling job %s", clusterName, job.Details.ID)
 				jsonBytes, err := json.Marshal(job)
 				if err != nil {
 					log.Println("json error: ", err)
 				} else {
+					log.Printf("%s: sending marshalled job %s", clusterName, job.Details.ID)
 					sse.events <- jsonBytes
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -75,6 +75,16 @@ func getJobs(c web.C, w http.ResponseWriter, r *http.Request) {
 	w.Write(jsonBytes)
 }
 
+func getNumClusters(c web.C, w http.ResponseWriter, r *http.Request) {
+	jsonBytes, err := json.Marshal(len(jts))
+	if err != nil {
+		log.Println("error:", err)
+		w.WriteHeader(500)
+		return
+	}
+	w.Write(jsonBytes)
+}
+
 func getConf(c web.C, w http.ResponseWriter, r *http.Request) {
 	id := c.URLParams["id"]
 	log.Printf("Getting job conf for %s", id)
@@ -214,6 +224,7 @@ func main() {
 	mux.Get("/static/*", static)
 	mux.Get("/", index)
 	mux.Get("/jobs/", getJobs)
+	mux.Get("/numClusters/", getNumClusters)
 	mux.Get("/sse", sse)
 	mux.Get("/jobs/:id", getJob)
 	mux.Get("/jobs/:id/conf", getConf)

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eslint": "^4.9.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-stripe": "^1.2.0",
+    "flow-bin": "^0.59.0",
     "gulp": "^3.9.1",
     "vinyl-source-stream": "^1.1.0"
   },
@@ -37,6 +38,7 @@
     "bin": "./bin"
   },
   "scripts": {
-    "test": "eslint --ext .js --ext .jsx ."
+    "flow": "flow",
+    "test": "flow && eslint --ext .js --ext .jsx ."
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
-    "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router": "^3.0.2",


### PR DESCRIPTION
Adds support for tracking jobs in multiple clusters. The invocation syntax is a bit clunky as a result:
```
$ /opt/timberlake/bin/timberlake \
      -bind :8000 \
      -cluster-name c1,c2 \
      -resource-manager-url rm1,rm2 \
      -history-server-url hs1,hs1 \
      -namenode-address nn1,nn2 \
      -yarn-logs-dir /var/log/hadoop-yarn/apps
      -yarn-history-dir /tmp/staging/history/done
      -pprof"
```
One needs to be careful to align cluster details consistently or things will break. Additionally, this assumes that YARN directories are the same for all clusters. I'm intending to add support for configuration files that lay out cluster mappings more intuitively in a future PR.

This also extends job history retention, 5k jobs per cluster on the server side (prev. 5k globally), and 10k jobs on the client (prev. 5k). The server side isn't much of a concern, as the intention is to run JT on a dedicated box in a multicluster setting. The client settings have not been thoroughly tested at the new limit, but dialing it back would be pretty straightforward.

The only visual regression for single clusters is the addition of a `cluster` column, which isn't useful in a single cluster setting:
![image](https://user-images.githubusercontent.com/23064962/33415313-8c625cc4-d54a-11e7-961a-51302db7fcf5.png)
I have a TODO to fix this and will file a GH issue as well.

There are a few other changes rolled into this PR, including improved error logging and eslint fixes. A possibly major change is the switch from PropTypes to flow (with `js/job.jsx` as the PoC), happy to 🏈 that to a separate PR if it's distracting).

r? @stripe/data-platform @jbalogh 