### PR TITLE
Fetch related jobs from server

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@ const browserify = require('browserify');
 const source = require('vinyl-source-stream');
 
 const paths = {
-  js: ['js/*/*.jsx'],
+  js: ['js/**/*.jsx', 'js/**/*.js'],
   copy: ['css/*.css', 'js/libs/*.js', 'img/*'],
 };
 

--- a/js/app.jsx
+++ b/js/app.jsx
@@ -113,4 +113,3 @@ render(
   </Router>
   , document.getElementById('timberlake'),
 );
-

--- a/js/job.jsx
+++ b/js/job.jsx
@@ -81,9 +81,6 @@ export default class Job extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    const {jobId} = this.props.params;
-    Store.getJob(jobId);
-
     ConfStore.on('jobConf', (jobConf) => (
       this.setState({
         jobConfs: _.extend(
@@ -112,7 +109,8 @@ export default class Job extends React.Component<Props, State> {
   handleHideKillModal: Function;
 
   handleNewJobID(jobId: string) {
-    Store.getJob(jobId);
+    Store.getJob(jobId)
+      .then((job) => Store.getRelatedJobs(job.flowId));
     ConfStore.getJobConf(jobId);
     relatedJobs(this.getJob(), this.props.jobs).forEach((job) => {
       ConfStore.getJobConf(job.id);

--- a/js/mr.js
+++ b/js/mr.js
@@ -9,6 +9,7 @@ export const notAvailable = {};
 export class MRJob {
   constructor(data) {
     this.cluster = data.cluster;
+    this.flowId = data.flowID;
     const d = data.details;
     this.id = d.id.replace('application_', 'job_');
     this.fullName = d.name;


### PR DESCRIPTION
Currently we determine related jobs by fetching all the available jobs from the server and checking client-side for related jobs. This PR changes the client behavior to call the related jobs API endpoint and fetch jobs accordingly

### Changes
- added `getRelatedJobs` to the store
- call `getRelatedJobs` when loading the job detail page
- only do the `getJobConf` API calls when we can't find it in the memory cache 
- minor fix to `gulpfile.js`
- support alternate counter names that we might get from S3

### Requested Feedback
not sure about handling multiple counter names on the frontend. should I just do that mapping on the backend to keep the frontend simpler?