### PR TITLE
Bump Go 1.6->1.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6
+FROM golang:1.9
 
 # Install node
 RUN if [ -e /usr/stripe/bin/docker/stripe-install-node ]; then /usr/stripe/bin/docker/stripe-install-node 6.9.2; else \


### PR DESCRIPTION
Yay supported releases.

Test plan: deployed to prod :yolo:

r? @stripe/data-platform 
cc @aditya-stripe 