### PR TITLE
Fix the kill functionality in JT

### DIFF
--- a/js/job.jsx
+++ b/js/job.jsx
@@ -123,7 +123,7 @@ export default class Job extends React.Component<Props, State> {
     const job = this.getJob();
     $.post(`/jobs/${job.id}/kill`, (data, status) => {
       console.log(data, status);
-      const result = (data && data.err) ? data.stderr : null;
+      const result = data.err ? data.stderr : null;
       this.setState({killResult: result});
     }).then(null, (err) => {
       console.error(err);

--- a/js/job.jsx
+++ b/js/job.jsx
@@ -123,7 +123,7 @@ export default class Job extends React.Component<Props, State> {
     const job = this.getJob();
     $.post(`/jobs/${job.id}/kill`, (data, status) => {
       console.log(data, status);
-      const result = data.err ? data.stderr : null;
+      const result = (data && data.err) ? data.stderr : null;
       this.setState({killResult: result});
     }).then(null, (err) => {
       console.error(err);

--- a/kill.go
+++ b/kill.go
@@ -19,6 +19,7 @@ func (jt *jobTracker) killJob(id string) error {
 	log.Println("Killing", id, req)
 
 	res, err := http.DefaultClient.Do(req)
+    log.Println("Whole status:", res)
 	log.Println("Kill status:", res.Status)
 
 	if res.StatusCode == 202 {

--- a/kill.go
+++ b/kill.go
@@ -19,7 +19,6 @@ func (jt *jobTracker) killJob(id string, user string) error {
 	log.Println("Killing", id, req)
 
 	res, err := http.DefaultClient.Do(req)
-    log.Println("Whole status:", res)
 	log.Println("Kill status:", res.Status)
 
 	if res.StatusCode == 202 {

--- a/kill.go
+++ b/kill.go
@@ -8,8 +8,8 @@ import (
 	"time"
 )
 
-func (jt *jobTracker) killJob(id string) error {
-	url := fmt.Sprintf("%s/ws/v1/cluster/apps/%s/state", jt.jobClient.getRMAddress(), id)
+func (jt *jobTracker) killJob(id string, user string) error {
+	url := fmt.Sprintf("%s/ws/v1/cluster/apps/%s/state?user.name=%s", jt.jobClient.getRMAddress(), id, user)
 	payload := strings.NewReader(`{"state":"KILLED"}`) //cheating
 	req, err := http.NewRequest("PUT", url, payload)
 	if err != nil {

--- a/kill.go
+++ b/kill.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (jt *jobTracker) killJob(id string) error {
-	url := fmt.Sprintf("%s/ws/v1/cluster/apps/%s/state", jt.rm, id)
+	url := fmt.Sprintf("%s/ws/v1/cluster/apps/%s/state", jt.jobClient.getRMAddress(), id)
 	payload := strings.NewReader(`{"state":"KILLED"}`) //cheating
 	req, err := http.NewRequest("PUT", url, payload)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -168,11 +168,10 @@ func getJobIdsAPIHandler(c web.C, w http.ResponseWriter, r *http.Request) {
 
 func killJob(c web.C, w http.ResponseWriter, r *http.Request) {
 	id := c.URLParams["id"]
-	jobID := jobID(id)
+	app, jobID := hadoopIDs(id)
 
 	for _, jt := range jts {
 		if _, ok := jt.jobs[jobID]; ok {
-			app, _ := hadoopIDs(id)
 			err := jt.killJob(app, jt.jobs[jobID].Details.User)
 			if err != nil {
 				log.Println("killJob error: ", err)

--- a/main.go
+++ b/main.go
@@ -172,7 +172,8 @@ func killJob(c web.C, w http.ResponseWriter, r *http.Request) {
 
 	for _, jt := range jts {
 		if _, ok := jt.jobs[jobID]; ok {
-			err := jt.killJob(id, jt.jobs[jobID].Details.User)
+			app, _ := hadoopIDs(id)
+			err := jt.killJob(app, jt.jobs[jobID].Details.User)
 			if err != nil {
 				log.Println("killJob error: ", err)
 				w.WriteHeader(500)

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func killJob(c web.C, w http.ResponseWriter, r *http.Request) {
 
 	for _, jt := range jts {
 		if _, ok := jt.jobs[jobID]; ok {
-			err := jt.killJob(id)
+			err := jt.killJob(id, jt.jobs[jobID].Details.User)
 			if err != nil {
 				log.Println("killJob error: ", err)
 				w.WriteHeader(500)

--- a/recentjobclient.go
+++ b/recentjobclient.go
@@ -21,6 +21,7 @@ type RecentJobClient interface {
 	listCounters(id string) ([]counter, error)
 	fetchConf(id string) (map[string]string, error)
 	getNamenodeAddress() string
+	getRMAddress() string
 }
 
 type hadoopJobClient struct {
@@ -85,6 +86,10 @@ func getJSON(url string, data interface{}) (string, error) {
 
 func (jt *hadoopJobClient) getNamenodeAddress() string {
 	return jt.namenodeAddresses
+}
+
+func (jt *hadoopJobClient) getRMAddress() string {
+	return jt.resourceManagerHost
 }
 
 func (jt *hadoopJobClient) listJobs() (*appsResp, error) {


### PR DESCRIPTION
We need recentJobClient to expose the RM address so we can use the yarn REST api.

r? @abdul-stripe @dug-stripe 
cc? @stripe/data-platform 