### PR TITLE
remove unused fields from jobtracker

### DIFF
--- a/jobtracker.go
+++ b/jobtracker.go
@@ -46,18 +46,14 @@ func hadoopIDs(id string) (string, jobID) {
 }
 
 type jobTracker struct {
-	jobClient       RecentJobClient
-	clusterName     string
-	jobs            map[jobID]*job
-	jobsLock        sync.Mutex
-	rm              string
-	hs              string
-	ps              string
-	namenodeAddress string
-	running         chan *job
-	finished        chan *job
-	backfill        chan *job
-	updates         chan *job
+	jobClient   RecentJobClient
+	clusterName string
+	jobs        map[jobID]*job
+	jobsLock    sync.Mutex
+	running     chan *job
+	finished    chan *job
+	backfill    chan *job
+	updates     chan *job
 }
 
 func newJobTracker(clusterName string, jobClient RecentJobClient) *jobTracker {
@@ -102,7 +98,7 @@ func (jt *jobTracker) runningJobLoop() {
 	}
 
 	for range time.Tick(*pollInterval) {
-		log.Printf("Listing running jobs in cluster %s on resource manager %s\n", jt.clusterName, jt.rm)
+		log.Printf("Listing running jobs in cluster %s\n", jt.clusterName)
 		running, err := jt.jobClient.listJobs()
 		if err != nil {
 			log.Println("Error listing running jobs:", err)

--- a/logs.go
+++ b/logs.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (jt *jobTracker) testLogsDir() error {
-	client, err := hdfs.New(jt.namenodeAddress)
+	client, err := hdfs.New(jt.jobClient.getNamenodeAddress())
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -3,9 +3,6 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"github.com/zenazn/goji/bind"
-	"github.com/zenazn/goji/web"
-	"github.com/zenazn/goji/web/middleware"
 	"log"
 	"net/http"
 	"net/http/pprof"
@@ -14,6 +11,10 @@ import (
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/zenazn/goji/bind"
+	"github.com/zenazn/goji/web"
+	"github.com/zenazn/goji/web/middleware"
 )
 
 var clusterNames = flag.String("cluster-name", "default", "The user-visible names for the clusters")
@@ -67,7 +68,7 @@ func getJobs(c web.C, w http.ResponseWriter, r *http.Request) {
 				},
 			})
 		}
-		log.Printf("Appending %d jobs for Cluster %s: %s %s\n", len(jobs), clusterName, tracker.hs, tracker.rm)
+		log.Printf("Appending %d jobs for Cluster %s\n", len(jobs), clusterName)
 	}
 
 	jsonBytes, err := json.Marshal(jobs)


### PR DESCRIPTION
i moved the fields `rm`, `hs`, `ps`, and `namenodeAddress`  to `recentJobClient.go` a while ago, but i never removed the fields from `jobtracker.go`.

removing them now to prevent any more bugs like https://github.com/stripe/timberlake/pull/93

r? @dug-stripe 
