### PR TITLE
Add links to resourcemanager / jobhistory

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -32,7 +32,7 @@ func (m *mockPersistedJobClient) FetchJob(id string) (*job, error) {
  */
 func setJobTracker(client RecentJobClient) *jobTracker {
 	jts = make(map[string]*jobTracker)
-	var jt = newJobTracker("foo", client)
+	var jt = newJobTracker("foo", "", "", client)
 	jts["testCluster"] = jt
 	return jt
 }

--- a/css/app.css
+++ b/css/app.css
@@ -122,6 +122,19 @@ a:hover,
 }
 /** progress bar **/
 
+.job-header {
+  display: flex;
+  justify-content: space-between;
+}
+
+.job-header-hadoop-link-container {
+  align-self: center;
+}
+
+.hadoop-link {
+  color: #428bca;
+}
+
 .job-details td {
   max-width: 500px;
   overflow: hidden;

--- a/job.go
+++ b/job.go
@@ -19,6 +19,8 @@ type job struct {
 	partial  bool
 	updated  time.Time
 	Cluster  string `json:"cluster"`
+	ResourceManagerURL string `json:"resourceManagerUrl"`
+	JobHistoryURL      string `json:"jobHistoryUrl"`
 
 	// http://docs.cascading.org/cascading/1.2/javadoc/cascading/flow/Flow.html
 	FlowID *string `json:"flowID"`

--- a/js/job.jsx
+++ b/js/job.jsx
@@ -171,7 +171,8 @@ export default class Job extends React.Component<Props, State> {
     const previous = prev ? <Link to={`job/${prev.id}`}>previous: {secondFormat(prev.duration())}</Link> : null;
 
     let state = jobState(job);
-    if (_.contains(ACTIVE_STATES, job.state)) {
+    const isActive = _.contains(ACTIVE_STATES, job.state);
+    if (isActive) {
       const {killing} = this.state;
       state = (
         <span>
@@ -256,8 +257,14 @@ export default class Job extends React.Component<Props, State> {
       <div>
         <div className="row">
           <div className="col-md-5">
-            <div>
+            <div className="job-header">
               <h4>Job Details</h4>
+              <div className="job-header-hadoop-link-container">
+                {isActive && job.resourceManagerUrl &&
+                  <a className="hadoop-link" href={job.resourceManagerUrl}>View in Resource Manager</a>}
+                {!isActive && job.jobHistoryUrl &&
+                  <a className="hadoop-link" href={job.jobHistoryUrl}>View in Job History</a>}
+              </div>
             </div>
             <table className="table job-details">
               <tbody>

--- a/js/job.jsx
+++ b/js/job.jsx
@@ -112,7 +112,11 @@ export default class Job extends React.Component<Props, State> {
 
   handleNewJobID(jobId: string) {
     Store.getJob(jobId)
-      .then((job) => Store.getRelatedJobs(job.flowId));
+      .then((job) => {
+        if (job.flowId) {
+          Store.getRelatedJobs(job.flowId);
+        }
+      });
     ConfStore.getJobConf(jobId);
     relatedJobs(this.getJob(), this.props.jobs).forEach((job) => {
       ConfStore.getJobConf(job.id);

--- a/js/mr.js
+++ b/js/mr.js
@@ -8,6 +8,8 @@ export class MRJob {
   constructor(data) {
     this.cluster = data.cluster;
     this.flowId = data.flowID;
+    this.resourceManagerUrl = data.resourceManagerUrl;
+    this.jobHistoryUrl = data.jobHistoryUrl;
     const d = data.details;
     this.id = d.id.replace('application_', 'job_');
     this.fullName = d.name;

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/zenazn/goji/bind"
 	"github.com/zenazn/goji/web"
 	"github.com/zenazn/goji/web/middleware"
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/pprof"
@@ -120,6 +121,11 @@ func getJob(rawJobID string) *job {
 		if _, ok := jt.jobs[jobID(rawJobID)]; ok {
 			job := jt.reifyJob(rawJobID)
 			job.Cluster = clusterName
+
+			appID, _jobID := hadoopIDs(rawJobID)
+			job.ResourceManagerURL = fmt.Sprintf("%s/cluster/app/%s", jt.jobClient.getRMAddress(), appID)
+			job.JobHistoryURL = fmt.Sprintf("%s/jobhistory/job/%s", jt.jobClient.getJobHistoryAddress(), _jobID)
+
 			return job
 		}
 	}

--- a/recentjobclient.go
+++ b/recentjobclient.go
@@ -22,6 +22,7 @@ type RecentJobClient interface {
 	fetchConf(id string) (map[string]string, error)
 	getNamenodeAddress() string
 	getRMAddress() string
+	getJobHistoryAddress() string
 }
 
 type hadoopJobClient struct {
@@ -90,6 +91,10 @@ func (jt *hadoopJobClient) getNamenodeAddress() string {
 
 func (jt *hadoopJobClient) getRMAddress() string {
 	return jt.resourceManagerHost
+}
+
+func (jt *hadoopJobClient) getJobHistoryAddress() string {
+	return jt.jobHistoryHost
 }
 
 func (jt *hadoopJobClient) listJobs() (*appsResp, error) {


### PR DESCRIPTION
Add links to the approrpriate hadoop UIs, in case users want to dive deep

Added two optional cmdline args: `public-resource-manager-url` and `public-history-server-url` because we don't have a single URL that's both publicly accessible + works with our internal servers.

r? @tchow-stripe @dug-stripe 