### PR TITLE
Fix race condition on map access

### DIFF
--- a/history.go
+++ b/history.go
@@ -90,6 +90,13 @@ type attemptEvent struct {
 	} `json:"counters"`
 }
 
+// HdfsJobHistoryClient fetches job history from HDFS
+type HdfsJobHistoryClient interface {
+	updateFromHistoryFile(jt *jobTracker, job *job, full bool) error
+}
+
+type hdfsJobHistoryClient struct {}
+
 type jhistParser struct {
 	job  *job
 	full bool
@@ -355,7 +362,7 @@ func findHistoryAndConfFiles(client *hdfs.Client, jobID jobID, finishTime int64)
 
 // updateFromHistoryFile updates a job's details by loading its saved 'jhist'
 // file stored in hdfs, along with the stored jobconf xml file.
-func (jt *jobTracker) updateFromHistoryFile(job *job, full bool) error {
+func (jc *hdfsJobHistoryClient) updateFromHistoryFile(jt *jobTracker, job *job, full bool) error {
 	now := time.Now()
 
 	client, err := hdfs.New(jt.jobClient.getNamenodeAddress())

--- a/history.go
+++ b/history.go
@@ -95,7 +95,7 @@ type HdfsJobHistoryClient interface {
 	updateFromHistoryFile(jt *jobTracker, job *job, full bool) error
 }
 
-type hdfsJobHistoryClient struct {}
+type hdfsJobHistoryClient struct{}
 
 type jhistParser struct {
 	job  *job

--- a/job.go
+++ b/job.go
@@ -74,16 +74,20 @@ type counter struct {
 	Reduce int    `json:"reduce"`
 }
 
-type appsResp struct {
-	Apps struct {
+type appsDetailList struct {
 		App []jobDetail `json:"app"`
-	} `json:"apps"`
+}
+
+type appsResp struct {
+	Apps appsDetailList `json:"apps"`
+}
+
+type jobsDetailList struct {
+	Job []jobDetail `json:"job"`
 }
 
 type jobsResp struct {
-	Jobs struct {
-		Job []jobDetail `json:"job"`
-	} `json:"jobs"`
+	Jobs jobsDetailList `json:"jobs"`
 	Job jobDetail `json:"job"`
 }
 

--- a/job.go
+++ b/job.go
@@ -11,14 +11,14 @@ type jobConf struct {
 // Avoid adding additional exported fields
 // as event streaming can overwhelm clients
 type job struct {
-	Details  jobDetail `json:"details"`
-	Counters []counter `json:"counters"`
-	conf     conf
-	Tasks    tasks `json:"tasks"`
-	running  bool
-	partial  bool
-	updated  time.Time
-	Cluster  string `json:"cluster"`
+	Details            jobDetail `json:"details"`
+	Counters           []counter `json:"counters"`
+	conf               conf
+	Tasks              tasks `json:"tasks"`
+	running            bool
+	partial            bool
+	updated            time.Time
+	Cluster            string `json:"cluster"`
 	ResourceManagerURL string `json:"resourceManagerUrl"`
 	JobHistoryURL      string `json:"jobHistoryUrl"`
 
@@ -75,7 +75,7 @@ type counter struct {
 }
 
 type appsDetailList struct {
-		App []jobDetail `json:"app"`
+	App []jobDetail `json:"app"`
 }
 
 type appsResp struct {
@@ -88,7 +88,7 @@ type jobsDetailList struct {
 
 type jobsResp struct {
 	Jobs jobsDetailList `json:"jobs"`
-	Job jobDetail `json:"job"`
+	Job  jobDetail      `json:"job"`
 }
 
 type confResp struct {

--- a/jobtracker.go
+++ b/jobtracker.go
@@ -47,37 +47,36 @@ func hadoopIDs(id string) (string, jobID) {
 }
 
 type jobTracker struct {
-	jobClient       RecentJobClient
-	jobHistoryClient HdfsJobHistoryClient
-	clusterName     string
+	jobClient                RecentJobClient
+	jobHistoryClient         HdfsJobHistoryClient
+	clusterName              string
 	publicResourceManagerURL string
-	publicHistoryServerURL string
-	jobs            map[jobID]*job
-	jobsLock        sync.Mutex
-	rm              string
-	hs              string
-	ps              string
-	namenodeAddress string
-	running         chan *job
-	finished        chan *job
-	backfill        chan *job
-	updates         chan *job
+	publicHistoryServerURL   string
+	jobs                     map[jobID]*job
+	jobsLock                 sync.Mutex
+	rm                       string
+	hs                       string
+	ps                       string
+	namenodeAddress          string
+	running                  chan *job
+	finished                 chan *job
+	backfill                 chan *job
+	updates                  chan *job
 }
-
 
 func newJobTracker(clusterName string, publicResourceManagerURL string, publicHistoryServerURL string, jobClient RecentJobClient, jobHistoryClient HdfsJobHistoryClient) *jobTracker {
 	return &jobTracker{
-		clusterName: clusterName,
-		jobHistoryClient: jobHistoryClient,
+		clusterName:              clusterName,
+		jobHistoryClient:         jobHistoryClient,
 		publicResourceManagerURL: publicResourceManagerURL,
-		publicHistoryServerURL: publicHistoryServerURL,
+		publicHistoryServerURL:   publicHistoryServerURL,
 
-		jobClient:   jobClient,
-		jobs:        make(map[jobID]*job),
-		running:     make(chan *job),
-		finished:    make(chan *job),
-		backfill:    make(chan *job),
-		updates:     make(chan *job),
+		jobClient: jobClient,
+		jobs:      make(map[jobID]*job),
+		running:   make(chan *job),
+		finished:  make(chan *job),
+		backfill:  make(chan *job),
+		updates:   make(chan *job),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -248,6 +248,7 @@ func main() {
 				proxyServerURL,
 				namenodeAddresses[i],
 			),
+			&hdfsJobHistoryClient{},
 		)
 	}
 

--- a/race_test.go
+++ b/race_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+  "time"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestJobTrackerJobsMapRace(t *testing.T) {
+  mockClient := new(mockJobClient)
+  mockHistoryClient := new(mockHdfsJobHistoryClient)
+
+  jobresp := jobsResp{
+    Jobs: jobsDetailList{
+      Job: []jobDetail{jobDetail{}},
+    },
+  }
+  mockClient.On("listFinishedJobs", mock.AnythingOfType("time.Time")).Return(&jobresp, nil)
+
+  appresp := appsResp{
+    Apps: appsDetailList{
+      App: []jobDetail{jobDetail{}},
+    },
+  }
+  mockClient.On("listJobs").Return(&appresp, nil)
+  jt := newJobTracker("foo", mockClient, mockHistoryClient)
+
+  jt.Loop()
+  time.Sleep(time.Second * 5)
+}

--- a/race_test.go
+++ b/race_test.go
@@ -1,30 +1,30 @@
 package main
 
 import (
-	"testing"
-  "time"
 	"github.com/stretchr/testify/mock"
+	"testing"
+	"time"
 )
 
 func TestJobTrackerJobsMapRace(t *testing.T) {
-  mockClient := new(mockJobClient)
-  mockHistoryClient := new(mockHdfsJobHistoryClient)
+	mockClient := new(mockJobClient)
+	mockHistoryClient := new(mockHdfsJobHistoryClient)
 
-  jobresp := jobsResp{
-    Jobs: jobsDetailList{
-      Job: []jobDetail{jobDetail{}},
-    },
-  }
-  mockClient.On("listFinishedJobs", mock.AnythingOfType("time.Time")).Return(&jobresp, nil)
+	jobresp := jobsResp{
+		Jobs: jobsDetailList{
+			Job: []jobDetail{jobDetail{}},
+		},
+	}
+	mockClient.On("listFinishedJobs", mock.AnythingOfType("time.Time")).Return(&jobresp, nil)
 
-  appresp := appsResp{
-    Apps: appsDetailList{
-      App: []jobDetail{jobDetail{}},
-    },
-  }
-  mockClient.On("listJobs").Return(&appresp, nil)
-  jt := newJobTracker("foo", "", "",  mockClient, mockHistoryClient)
+	appresp := appsResp{
+		Apps: appsDetailList{
+			App: []jobDetail{jobDetail{}},
+		},
+	}
+	mockClient.On("listJobs").Return(&appresp, nil)
+	jt := newJobTracker("foo", "", "", mockClient, mockHistoryClient)
 
-  jt.Loop()
-  time.Sleep(time.Second * 5)
+	jt.Loop()
+	time.Sleep(time.Second * 5)
 }

--- a/race_test.go
+++ b/race_test.go
@@ -23,7 +23,7 @@ func TestJobTrackerJobsMapRace(t *testing.T) {
     },
   }
   mockClient.On("listJobs").Return(&appresp, nil)
-  jt := newJobTracker("foo", mockClient, mockHistoryClient)
+  jt := newJobTracker("foo", "", "",  mockClient, mockHistoryClient)
 
   jt.Loop()
   time.Sleep(time.Second * 5)

--- a/s3jobresponse.go
+++ b/s3jobresponse.go
@@ -13,7 +13,7 @@ type S3JobDetail struct {
 	State      string            `json:"outcome"`
 	Conf       map[string]string `json:"job_properties"`
 
-	MapTasks []task `json:"map_tasks"`
+	MapTasks    []task `json:"map_tasks"`
 	ReduceTasks []task `json:"reduce_tasks"`
 
 	MapCounters    map[string]int `json:"map_counters"`
@@ -24,8 +24,8 @@ type S3JobDetail struct {
 }
 
 type task struct {
-	StartTime int64 `json:"launch_date"`
-	EndTime   int64 `json:"finish_date"`
+	StartTime int64  `json:"launch_date"`
+	EndTime   int64  `json:"finish_date"`
 	Status    string `json:"task_status"`
 }
 
@@ -99,13 +99,13 @@ func s3responseToJobConf(s *S3JobDetail) conf {
 }
 
 func filter(vs []task, f func(task) bool) []task {
-    vsf := make([]task, 0)
-    for _, v := range vs {
-        if f(v) {
-            vsf = append(vsf, v)
-        }
-    }
-    return vsf
+	vsf := make([]task, 0)
+	for _, v := range vs {
+		if f(v) {
+			vsf = append(vsf, v)
+		}
+	}
+	return vsf
 }
 
 func s3jobdetailToJobDetail(s *S3JobDetail) jobDetail {
@@ -124,20 +124,20 @@ func s3jobdetailToJobDetail(s *S3JobDetail) jobDetail {
 
 		MapsTotal:     s.MapsTotal,
 		MapProgress:   100,
-		MapsPending: 0,
-		MapsRunning: 0,
-		MapsCompleted: len(filter(s.MapTasks, func (t task) bool { return t.Status == "SUCCESS" })),
-		MapsFailed: len(filter(s.MapTasks, func (t task) bool { return t.Status == "FAILED" })),
-		MapsKilled: len(filter(s.MapTasks, func (t task) bool { return t.Status == "KILLED" })),
+		MapsPending:   0,
+		MapsRunning:   0,
+		MapsCompleted: len(filter(s.MapTasks, func(t task) bool { return t.Status == "SUCCESS" })),
+		MapsFailed:    len(filter(s.MapTasks, func(t task) bool { return t.Status == "FAILED" })),
+		MapsKilled:    len(filter(s.MapTasks, func(t task) bool { return t.Status == "KILLED" })),
 		MapsTotalTime: int64(s.MapCounters["CPU_MILLISECONDS"]),
 
 		ReducesTotal:     s.ReducesTotal,
 		ReduceProgress:   100,
-		ReducesPending: 0,
-		ReducesRunning: 0,
-		ReducesCompleted: len(filter(s.ReduceTasks, func (t task) bool { return t.Status == "SUCCESS" })),
-		ReducesFailed: len(filter(s.ReduceTasks, func (t task) bool { return t.Status == "FAILED" })),
-		ReducesKilled: len(filter(s.ReduceTasks, func (t task) bool { return t.Status == "KILLED" })),
+		ReducesPending:   0,
+		ReducesRunning:   0,
+		ReducesCompleted: len(filter(s.ReduceTasks, func(t task) bool { return t.Status == "SUCCESS" })),
+		ReducesFailed:    len(filter(s.ReduceTasks, func(t task) bool { return t.Status == "FAILED" })),
+		ReducesKilled:    len(filter(s.ReduceTasks, func(t task) bool { return t.Status == "KILLED" })),
 		ReducesTotalTime: int64(s.ReduceCounters["CPU_MILLISECONDS"]),
 	}
 }


### PR DESCRIPTION
We've been getting crashes a couple times a day that look like:

```
fatal error: concurrent map iteration and map write
```

I'm guessing this is probably the cause, considering this is the only loop that doesn't lock before accessing `jt.jobs`

r? @dug-stripe 